### PR TITLE
k6 smoke: use setup action, remove credential-based login, simplify script

### DIFF
--- a/.github/workflows/k6-smoke.yml
+++ b/.github/workflows/k6-smoke.yml
@@ -12,20 +12,14 @@ permissions:
 jobs:
   k6-smoke:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Install k6
-        run: |
-          sudo gpg -k
-          curl -s https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/k6-archive-keyring.gpg
-          echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-          sudo apt-get update
-          sudo apt-get install -y k6
+      - name: Set up k6
+        uses: grafana/setup-k6-action@v1
+        with:
+          k6-version: '2.0.0'
 
       - name: Run k6 API smoke test
         id: k6-run
@@ -33,17 +27,15 @@ jobs:
         env:
           BASE_URL: ${{ vars.PERF_BASE_URL || secrets.PERF_BASE_URL }}
           API_TOKEN: ${{ secrets.PERF_API_TOKEN }}
-          SMOKE_EMAIL: ${{ secrets.PERF_SMOKE_EMAIL }}
-          SMOKE_PASSWORD: ${{ secrets.PERF_SMOKE_PASSWORD }}
-        continue-on-error: true
         run: |
+          k6 version
           k6 run \
             --summary-export k6-summary.json \
             smoke.js
 
       - name: Upload k6 summary
         if: always() && hashFiles('perf/k6-summary.json') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: k6-summary
           path: perf/k6-summary.json

--- a/perf/endpoints.json
+++ b/perf/endpoints.json
@@ -6,18 +6,6 @@
     "expectedStatus": 200
   },
   {
-    "name": "login",
-    "method": "POST",
-    "path": "/api/auth/login",
-    "body": {
-      "email": "${SMOKE_EMAIL}",
-      "password": "${SMOKE_PASSWORD}"
-    },
-    "expectedStatus": 200,
-    "requiresCredentials": true,
-    "captureToken": true
-  },
-  {
     "name": "current_user",
     "method": "GET",
     "path": "/api/auth/me",

--- a/perf/smoke.js
+++ b/perf/smoke.js
@@ -4,9 +4,6 @@ import { SharedArray } from 'k6/data';
 
 const BASE_URL = (__ENV.BASE_URL || '').replace(/\/$/, '');
 const API_TOKEN = __ENV.API_TOKEN || '';
-const SMOKE_EMAIL = __ENV.SMOKE_EMAIL || '';
-const SMOKE_PASSWORD = __ENV.SMOKE_PASSWORD || '';
-let authToken = API_TOKEN;
 
 if (!BASE_URL) {
   throw new Error('BASE_URL is required');
@@ -32,39 +29,12 @@ export const options = {
   },
 };
 
-function resolveBody(body) {
-  if (!body) {
-    return {};
-  }
-
-  const text = JSON.stringify(body)
-    .replaceAll('${SMOKE_EMAIL}', SMOKE_EMAIL)
-    .replaceAll('${SMOKE_PASSWORD}', SMOKE_PASSWORD);
-
-  return JSON.parse(text);
-}
-
 function shouldSkip(api) {
-  if (api.requiresToken && !authToken) {
-    return true;
-  }
-
-  if (api.requiresCredentials && (!SMOKE_EMAIL || !SMOKE_PASSWORD)) {
+  if (api.requiresToken && !API_TOKEN) {
     return true;
   }
 
   return false;
-}
-
-function captureAuthToken(api, response) {
-  if (!api.captureToken || response.status !== api.expectedStatus) {
-    return;
-  }
-
-  const body = response.json();
-  if (body && typeof body.token === 'string') {
-    authToken = body.token;
-  }
 }
 
 export default function () {
@@ -79,15 +49,15 @@ export default function () {
       'Content-Type': 'application/json',
     };
 
-    if (authToken) {
-      headers.Authorization = `Bearer ${authToken}`;
+    if (API_TOKEN) {
+      headers.Authorization = `Bearer ${API_TOKEN}`;
     }
 
     const params = {
       headers,
       tags: { api: api.name },
     };
-    const body = JSON.stringify(resolveBody(api.body));
+    const body = api.body ? JSON.stringify(api.body) : null;
     let response;
 
     if (method === 'POST') {
@@ -104,8 +74,6 @@ export default function () {
       [`${api.name} status is ${api.expectedStatus}`]: (r) => r.status === api.expectedStatus,
       [`${api.name} response time < 800ms`]: (r) => r.timings.duration < 800,
     });
-
-    captureAuthToken(api, response);
 
     sleep(1);
   }


### PR DESCRIPTION
### Motivation
- Replace fragile manual k6 installation and older actions with maintained setup actions and newer action versions to improve reliability.
- Remove credential-based login flow from the smoke test in favor of using a single `API_TOKEN` to simplify authentication.
- Simplify the smoke script to avoid capturing tokens at runtime and reduce environment requirements for scheduled runs.

### Description
- Updated `.github/workflows/k6-smoke.yml` to use `actions/checkout@v6`, removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, replaced manual apt installation with `grafana/setup-k6-action@v1` (setting `k6-version: '2.0.0'`), added `k6 version` output, and upgraded `actions/upload-artifact` to `@v7`.
- Removed `login` endpoint from `perf/endpoints.json` and eliminated references to `SMOKE_EMAIL`/`SMOKE_PASSWORD` to drop credential-based login from the scenario.
- Simplified `perf/smoke.js` by removing `SMOKE_EMAIL`/`SMOKE_PASSWORD`, removing `resolveBody` and `captureAuthToken` helpers, using `API_TOKEN` directly for the `Authorization` header, and sending `api.body` as-is when present.

### Testing
- No automated tests were added for this change.
- The updated workflow is configured to run on schedule and can be triggered via `workflow_dispatch` for manual execution.
- Basic local validation can be performed with `k6 version` and `k6 run perf/smoke.js` against a configured `PERF_BASE_URL` and `PERF_API_TOKEN`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eaa07c28083329f2d82409a11172c)