### PR TITLE
Unify AI workbench routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/NotFound";
-import { Route, Switch, Redirect, useLocation } from "wouter";
+import { Route, Switch, Redirect } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { Layout } from "./components/Layout";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { AuthProvider } from "./contexts/AuthContext";
 import { NavCollapseProvider } from "./contexts/NavCollapseContext";
-import { AiGenerationProvider, useAiGeneration } from "./contexts/AiGenerationContext";
+import { AiGenerationProvider } from "./contexts/AiGenerationContext";
 import Home from "./pages/Home";
 import Landing from "./pages/Landing";
 import Login from "./pages/Login";
@@ -20,15 +20,19 @@ import Tasks from "./pages/tasks/Tasks";
 import APICases from "./pages/cases/APICases";
 import UICases from "./pages/cases/UICases";
 import PerformanceCases from "./pages/cases/PerformanceCases";
-import AICases from "./pages/cases/AICases";
-import AICaseCreate from "./pages/cases/AICaseCreate";
-import AICaseHistory from "./pages/cases/AICaseHistory";
+import AiWorkbenchOverview from "./pages/ai-workbench/AiWorkbenchOverview";
+import AiWorkbenchRequirementInput from "./pages/ai-workbench/AiWorkbenchRequirementInput";
+import AiWorkbenchRequirementAnalysis from "./pages/ai-workbench/AiWorkbenchRequirementAnalysis";
+import AiWorkbenchCaseGeneration from "./pages/ai-workbench/AiWorkbenchCaseGeneration";
+import AiWorkbenchQualityCoverage from "./pages/ai-workbench/AiWorkbenchQualityCoverage";
+import AiWorkbenchHistoryExport from "./pages/ai-workbench/AiWorkbenchHistoryExport";
+import AiWorkbenchSettings from "./pages/ai-workbench/AiWorkbenchSettings";
 import Reports from "./pages/reports/Reports";
 import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
 import { User } from "lucide-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -65,60 +69,11 @@ function ProfilePage() {
   );
 }
 
-/**
- * AI 用例保活组件：
- * - 只要曾经访问过 /cases/ai 就会挂载
- * - AI 生成中切换到其他路由时：用 visibility:hidden + 绝对定位保留 DOM 状态
- * - 当前路由是 /cases/ai：fixed inset-0 覆盖全屏，正常显示
- * - 非当前路由且未在生成：display:none（节省资源，但保活已挂载）
- */
-function KeepAliveAiCases() {
-  const [location] = useLocation();
-  const { isGenerating } = useAiGeneration();
-  // 用 useState 惰性初始化：如果刷新时直接落在 /cases/ai，也能立即挂载
-  const [hasVisited, setHasVisited] = useState(
-    () => location === '/cases/ai' || location.startsWith('/cases/ai?')
-  );
-
-  const isCurrentRoute = location === '/cases/ai' || location.startsWith('/cases/ai?');
-
-  // 一旦用户导航到 /cases/ai，就永久标记（不会因路由变化而重置）
-  useEffect(() => {
-    if (isCurrentRoute && !hasVisited) {
-      setHasVisited(true);
-    }
-  }, [isCurrentRoute, hasVisited]);
-
-  // 未访问过 且 不在生成中 → 无需挂载
-  const shouldMount = hasVisited || isGenerating;
-  if (!shouldMount) {
-    return null;
-  }
-
-  if (isCurrentRoute) {
-    // 当前路由：用 fixed inset-0 覆盖全屏，与 Switch 内容互斥展示
-    // z-index 设置较高确保覆盖在 Switch 渲染的空占位之上
-    return (
-      <div className="fixed inset-0 z-10">
-        <ProtectedRoute>
-          <Layout>
-            <AICases />
-          </Layout>
-        </ProtectedRoute>
-      </div>
-    );
-  }
-
-  // 不在当前路由：隐藏但保留 DOM（保活核心）
-  // display:none 会让浏览器跳过渲染，但 React 组件树和状态完整保留
+function ProtectedLayout({ children }: { children: ReactNode }) {
   return (
-    <div style={{ display: 'none' }}>
-      <ProtectedRoute>
-        <Layout>
-          <AICases />
-        </Layout>
-      </ProtectedRoute>
-    </div>
+    <ProtectedRoute>
+      <Layout>{children}</Layout>
+    </ProtectedRoute>
   );
 }
 
@@ -167,23 +122,58 @@ function Router() {
             </Layout>
           </ProtectedRoute>
         </Route>
-        <Route path="/cases/ai-create">
-          <ProtectedRoute>
-            <Layout>
-              <AICaseCreate />
-            </Layout>
-          </ProtectedRoute>
+        <Route path="/ai-workbench/index">
+          <Redirect to="/ai-workbench/overview" />
         </Route>
-        {/* /cases/ai 路由由 KeepAliveAiCases 接管，Switch 中仅保留空占位避免 404 */}
-        <Route path="/cases/ai">
-          {null}
+        <Route path="/ai-workbench/home">
+          <Redirect to="/ai-workbench/overview" />
+        </Route>
+        <Route path="/ai-workbench/records">
+          <Redirect to="/ai-workbench/history-export" />
+        </Route>
+        <Route path="/ai-workbench/overview">
+          <ProtectedLayout>
+            <AiWorkbenchOverview />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/requirement-input">
+          <ProtectedLayout>
+            <AiWorkbenchRequirementInput />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/requirement-analysis">
+          <ProtectedLayout>
+            <AiWorkbenchRequirementAnalysis />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/case-generation">
+          <ProtectedLayout>
+            <AiWorkbenchCaseGeneration />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/quality-coverage">
+          <ProtectedLayout>
+            <AiWorkbenchQualityCoverage />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/history-export">
+          <ProtectedLayout>
+            <AiWorkbenchHistoryExport />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/settings">
+          <ProtectedLayout>
+            <AiWorkbenchSettings />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/cases/ai-create">
+          <Redirect to="/ai-workbench/overview" />
         </Route>
         <Route path="/cases/ai-history">
-          <ProtectedRoute>
-            <Layout>
-              <AICaseHistory />
-            </Layout>
-          </ProtectedRoute>
+          <Redirect to="/ai-workbench/history-export" />
+        </Route>
+        <Route path="/cases/ai">
+          <Redirect to="/ai-workbench/overview" />
         </Route>
 
         <Route path="/tasks">
@@ -226,8 +216,6 @@ function Router() {
         <Route component={NotFound} />
       </Switch>
 
-      {/* 保活层：永久挂载在 Switch 外部，不受路由切换影响 */}
-      <KeepAliveAiCases />
     </>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,10 @@ import {
   Gauge,
   BrainCircuit,
   History,
+  ClipboardList,
+  Target,
+  FileText,
+  ShieldCheck,
   PanelLeftClose,
   PanelLeftOpen
 } from "lucide-react";
@@ -54,8 +58,13 @@ const navItems: NavItem[] = [
     icon: <BrainCircuit className="h-5 w-5" />,
     label: "AI 工作台",
     children: [
-      { label: "工作台首页", href: "/cases/ai-create", icon: <BrainCircuit className="h-4 w-4" /> },
-      { label: "全部记录", href: "/cases/ai-history", icon: <History className="h-4 w-4" /> },
+      { label: "工作台总览", href: "/ai-workbench/overview", icon: <BrainCircuit className="h-4 w-4" /> },
+      { label: "需求输入与解析", href: "/ai-workbench/requirement-input", icon: <ClipboardList className="h-4 w-4" /> },
+      { label: "需求分析与测试点", href: "/ai-workbench/requirement-analysis", icon: <Target className="h-4 w-4" /> },
+      { label: "用例生成与编辑", href: "/ai-workbench/case-generation", icon: <FileText className="h-4 w-4" /> },
+      { label: "质量检查与覆盖率", href: "/ai-workbench/quality-coverage", icon: <ShieldCheck className="h-4 w-4" /> },
+      { label: "历史记录与导出", href: "/ai-workbench/history-export", icon: <History className="h-4 w-4" /> },
+      { label: "设置", href: "/ai-workbench/settings", icon: <Settings className="h-4 w-4" /> },
     ],
   },
   { icon: <Boxes className="h-5 w-5" />, label: "任务管理", href: "/tasks" },

--- a/src/pages/ai-workbench/AiWorkbenchCaseGeneration.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchCaseGeneration.tsx
@@ -1,0 +1,5 @@
+import AICases from '@/pages/cases/AICases';
+
+export default function AiWorkbenchCaseGeneration(): JSX.Element {
+  return <AICases />;
+}

--- a/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
@@ -1,0 +1,5 @@
+import AICaseHistory from '@/pages/cases/AICaseHistory';
+
+export default function AiWorkbenchHistoryExport(): JSX.Element {
+  return <AICaseHistory />;
+}

--- a/src/pages/ai-workbench/AiWorkbenchOverview.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchOverview.tsx
@@ -1,0 +1,5 @@
+import AICaseCreate from '@/pages/cases/AICaseCreate';
+
+export default function AiWorkbenchOverview(): JSX.Element {
+  return <AICaseCreate />;
+}

--- a/src/pages/ai-workbench/AiWorkbenchPlaceholder.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchPlaceholder.tsx
@@ -1,0 +1,23 @@
+import ComingSoon from '@/pages/ComingSoon';
+import { BarChart3, ClipboardList, Settings, Target } from 'lucide-react';
+
+interface AiWorkbenchPlaceholderProps {
+  title: string;
+  description: string;
+  icon: 'clipboard' | 'target' | 'chart' | 'settings';
+}
+
+const icons = {
+  clipboard: <ClipboardList className="h-10 w-10 text-blue-500" />,
+  target: <Target className="h-10 w-10 text-blue-500" />,
+  chart: <BarChart3 className="h-10 w-10 text-blue-500" />,
+  settings: <Settings className="h-10 w-10 text-blue-500" />,
+} satisfies Record<AiWorkbenchPlaceholderProps['icon'], JSX.Element>;
+
+export default function AiWorkbenchPlaceholder({
+  title,
+  description,
+  icon,
+}: AiWorkbenchPlaceholderProps): JSX.Element {
+  return <ComingSoon title={title} description={description} icon={icons[icon]} />;
+}

--- a/src/pages/ai-workbench/AiWorkbenchQualityCoverage.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchQualityCoverage.tsx
@@ -1,0 +1,11 @@
+import AiWorkbenchPlaceholder from './AiWorkbenchPlaceholder';
+
+export default function AiWorkbenchQualityCoverage(): JSX.Element {
+  return (
+    <AiWorkbenchPlaceholder
+      title="质量检查与覆盖率"
+      description="覆盖率统计、质量检查和风险提示能力正在整合"
+      icon="chart"
+    />
+  );
+}

--- a/src/pages/ai-workbench/AiWorkbenchRequirementAnalysis.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchRequirementAnalysis.tsx
@@ -1,0 +1,11 @@
+import AiWorkbenchPlaceholder from './AiWorkbenchPlaceholder';
+
+export default function AiWorkbenchRequirementAnalysis(): JSX.Element {
+  return (
+    <AiWorkbenchPlaceholder
+      title="需求分析与测试点"
+      description="需求歧义识别、风险分析和测试点拆解能力正在整合"
+      icon="target"
+    />
+  );
+}

--- a/src/pages/ai-workbench/AiWorkbenchRequirementInput.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchRequirementInput.tsx
@@ -1,0 +1,11 @@
+import AiWorkbenchPlaceholder from './AiWorkbenchPlaceholder';
+
+export default function AiWorkbenchRequirementInput(): JSX.Element {
+  return (
+    <AiWorkbenchPlaceholder
+      title="需求输入与解析"
+      description="需求上传、文本录入和 AI 解析入口正在整合到统一 AI 工作台"
+      icon="clipboard"
+    />
+  );
+}

--- a/src/pages/ai-workbench/AiWorkbenchSettings.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchSettings.tsx
@@ -1,0 +1,11 @@
+import AiWorkbenchPlaceholder from './AiWorkbenchPlaceholder';
+
+export default function AiWorkbenchSettings(): JSX.Element {
+  return (
+    <AiWorkbenchPlaceholder
+      title="AI 工作台设置"
+      description="模型偏好、导出模板和团队协作设置正在开发中"
+      icon="settings"
+    />
+  );
+}

--- a/src/pages/cases/AICaseCreate.tsx
+++ b/src/pages/cases/AICaseCreate.tsx
@@ -457,8 +457,8 @@ export default function AICaseCreate(): JSX.Element {
   const rows = useMemo(() => buildProjectRows(sortedDocs), [sortedDocs]);
   const userName = user?.display_name || user?.username || '张伟';
 
-  const handleOpen = useCallback((id: string) => setLocation(`/cases/ai?docId=${encodeURIComponent(id)}`), [setLocation]);
-  const handleViewAll = useCallback(() => setLocation('/cases/ai-history'), [setLocation]);
+  const handleOpen = useCallback((id: string) => setLocation(`/ai-workbench/case-generation?docId=${encodeURIComponent(id)}`), [setLocation]);
+  const handleViewAll = useCallback(() => setLocation('/ai-workbench/history-export'), [setLocation]);
   const handleReserved = useCallback((message: string) => toast.info(message), []);
 
   const metrics = useMemo<DashboardMetric[]>(() => [

--- a/src/pages/cases/AICaseHistory.tsx
+++ b/src/pages/cases/AICaseHistory.tsx
@@ -112,7 +112,7 @@ export default function AICaseHistory() {
   useEffect(() => { load(); }, [load]);
 
   const handleOpen = useCallback(
-    (id: string) => setLocation(`/cases/ai?docId=${encodeURIComponent(id)}`),
+    (id: string) => setLocation(`/ai-workbench/case-generation?docId=${encodeURIComponent(id)}`),
     [setLocation]
   );
 
@@ -207,7 +207,7 @@ export default function AICaseHistory() {
               size="sm"
               variant="outline"
               className="h-8 text-xs gap-1.5"
-              onClick={() => setLocation('/cases/ai-create')}
+              onClick={() => setLocation('/ai-workbench/overview')}
             >
               <ArrowLeft className="h-3.5 w-3.5" />
               返回首页
@@ -221,7 +221,7 @@ export default function AICaseHistory() {
             </Button>
             <Button
               size="sm" className="h-8 text-xs gap-1.5"
-              onClick={() => setLocation('/cases/ai-create')}
+              onClick={() => setLocation('/ai-workbench/overview')}
             >
               <BrainCircuit className="h-3.5 w-3.5" />
               新建生成
@@ -355,7 +355,7 @@ export default function AICaseHistory() {
               <p className="text-sm text-slate-400 dark:text-slate-500 mb-6 max-w-xs">
                 去「AI 生成用例」页面，输入需求描述来生成你的第一批测试用例
               </p>
-              <Button className="gap-1.5" onClick={() => setLocation('/cases/ai-create')}>
+              <Button className="gap-1.5" onClick={() => setLocation('/ai-workbench/overview')}>
                 <BrainCircuit className="h-4 w-4" />开始生成
               </Button>
             </div>

--- a/src/pages/cases/AICases.tsx
+++ b/src/pages/cases/AICases.tsx
@@ -1099,7 +1099,7 @@ const applyWorkspaceDetail = useCallback(
     <AICasesWorkspaceView
       saveStateText={saveStateText}
       remoteStatusText={remoteStatusText}
-      onOpenHistory={() => setLocation('/cases/ai-history')}
+      onOpenHistory={() => setLocation('/ai-workbench/history-export')}
       workspaceSummary={workspaceSummary}
       isRemoteLinked={isRemoteLinked}
       activeTab={activeTab}

--- a/src/pages/cases/AICasesActions.ts
+++ b/src/pages/cases/AICasesActions.ts
@@ -216,7 +216,7 @@ if (!requirementText.trim()) {
       finishGenerateProgress(generated.source === 'llm' ? 'AI 生成完成' : '模板生成完成');
 
       // 判断用户是否已离开 AI 用例页，若已离开则弹跨页面 toast
-      const isOnAiPage = window.location.pathname === '/cases/ai';
+      const isOnAiPage = window.location.pathname === '/ai-workbench/case-generation';
       if (isOnAiPage) {
         toast.success(`AI 用例生成完成（${generated.source === 'llm' ? '大模型' : '回退模板'}）`);
       } else {
@@ -224,7 +224,7 @@ if (!requirementText.trim()) {
           duration: 8000,
           action: {
             label: '返回查看',
-            onClick: () => setLocation('/cases/ai'),
+            onClick: () => setLocation('/ai-workbench/case-generation'),
           },
         });
       }
@@ -256,7 +256,7 @@ if (!requirementText.trim()) {
         errMsg.includes('HTTP 401') ||
         errMsg.includes('未认证');
 
-      const isOnAiPageOnError = window.location.pathname === '/cases/ai';
+      const isOnAiPageOnError = window.location.pathname === '/ai-workbench/case-generation';
       if (isAuthError) {
         toast.warning('登录状态已过期，AI 生成已切换至本地模板。请重新登录后再试', {
           duration: 6000,
@@ -270,7 +270,7 @@ if (!requirementText.trim()) {
           duration: 8000,
           action: {
             label: '返回查看',
-            onClick: () => setLocation('/cases/ai'),
+            onClick: () => setLocation('/ai-workbench/case-generation'),
           },
         });
       } else {

--- a/src/pages/cases/components/NewRequirementSheet.tsx
+++ b/src/pages/cases/components/NewRequirementSheet.tsx
@@ -112,7 +112,7 @@ export function NewRequirementSheet({ open, onOpenChange }: NewRequirementSheetP
       params.set('autoGenerate', autoGenerate ? 'true' : 'false');
       params.set('initName', workspaceName.trim() || 'AI Testcase Workspace');
       params.set('initReq', requirementText.trim());
-      setLocation(`/cases/ai?${params.toString()}`);
+      setLocation(`/ai-workbench/case-generation?${params.toString()}`);
     } catch (error) {
       console.error('[AICaseCreate] failed to navigate', error);
       toast.error('跳转失败，请重试');


### PR DESCRIPTION
### Motivation
- Consolidate AI-related pages under a single `ai-workbench` namespace to simplify navigation and future feature expansion.  
- Replace legacy `/cases/ai*` entry points with a consistent protected layout and explicit sub-pages.  
- Keep existing business pages (overview, case generation, history/export) while providing placeholders for sections still under development.  

### Description
- Added a new page folder `src/pages/ai-workbench/` with wrapper components that reuse existing business pages and placeholders for incomplete sections (`Overview`, `RequirementInput`, `RequirementAnalysis`, `CaseGeneration`, `QualityCoverage`, `HistoryExport`, `Settings`).  
- Reworked `src/App.tsx` to import the new `ai-workbench` components, introduced `ProtectedLayout` (wraps `ProtectedRoute` + `Layout`), added seven protected routes under `/ai-workbench/*`, and added redirects for legacy aliases `/ai-workbench/index`, `/ai-workbench/home`, and `/ai-workbench/records`.  
- Deprecated direct mounting of legacy pages by replacing `/cases/ai-create`, `/cases/ai-history`, and `/cases/ai` routes with redirects to the new `ai-workbench` routes and removed the old KeepAlive mount for `/cases/ai`.  
- Updated navigation and internal links to use the new paths: `src/components/Sidebar.tsx` menu items now point to the seven `ai-workbench` routes, and internal `setLocation` calls were migrated to the new routes in several AI case files (e.g., `AICaseCreate`, `AICaseHistory`, `AICases`, `AICasesActions`, `NewRequirementSheet`).  
- New files created: multiple `src/pages/ai-workbench/*.tsx` wrappers and a `AiWorkbenchPlaceholder` common component; modified routing, sidebar, and AI-case navigation logic across several files.  

### Testing
- Ran TypeScript checks with `npx tsc --noEmit -p tsconfig.json`, which succeeded.  
- Built the frontend with `npm run build`, which completed successfully.  
- Verified no whitespace/diff issues with `git diff --check`.  
- Attempted `npx vitest run` (test runner) but it did not complete in this environment and was terminated, so unit tests were not fully validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eb26b39348332b9b5896f0740e25d)