### PR TITLE
Add Requirement Input & Parsing page with cleaning utilities and UI components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import PerformanceCases from "./pages/cases/PerformanceCases";
 import AICases from "./pages/cases/AICases";
 import AICaseCreate from "./pages/cases/AICaseCreate";
 import AICaseHistory from "./pages/cases/AICaseHistory";
+import RequirementInputParsePage from "./pages/cases/RequirementInputParsePage";
 import Reports from "./pages/reports/Reports";
 import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
@@ -182,6 +183,13 @@ function Router() {
           <ProtectedRoute>
             <Layout>
               <AICaseHistory />
+            </Layout>
+          </ProtectedRoute>
+        </Route>
+        <Route path="/requirements/input-parse">
+          <ProtectedRoute>
+            <Layout>
+              <RequirementInputParsePage />
             </Layout>
           </ProtectedRoute>
         </Route>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Gauge,
   BrainCircuit,
   History,
+  ClipboardList,
   PanelLeftClose,
   PanelLeftOpen
 } from "lucide-react";
@@ -55,6 +56,7 @@ const navItems: NavItem[] = [
     label: "AI 工作台",
     children: [
       { label: "工作台首页", href: "/cases/ai-create", icon: <BrainCircuit className="h-4 w-4" /> },
+      { label: "需求输入与解析", href: "/requirements/input-parse", icon: <ClipboardList className="h-4 w-4" /> },
       { label: "全部记录", href: "/cases/ai-history", icon: <History className="h-4 w-4" /> },
     ],
   },

--- a/src/components/__tests__/RequirementInputUtils.test.tsx
+++ b/src/components/__tests__/RequirementInputUtils.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { cleanRequirementText, defaultCleanRules, formatFileSize, getFileType } from '@/lib/requirementInput';
+
+describe('cleanRequirementText', () => {
+  it('removes empty lines and extra spaces while preserving heading levels', () => {
+    const input = `1. 项目概述\n\n  本需求文档   描述会员中心。\n\n2.1 会员注册\n  - 用户可通过手机号、邮箱进行注册。`;
+
+    expect(cleanRequirementText(input, defaultCleanRules)).toBe(
+      `1. 项目概述\n本需求文档 描述会员中心。\n2.1 会员注册\n- 用户可通过手机号、邮箱进行注册。`
+    );
+  });
+
+  it('removes invisible garbled characters without removing line breaks', () => {
+    const input = '用户\u0000注册\n系统\u0007校验';
+
+    expect(cleanRequirementText(input, defaultCleanRules)).toBe('用户注册，系统校验');
+  });
+
+  it('merges abnormal line breaks for split sentences', () => {
+    const input = `用户点击领取后，\n系统需要判断库存。`;
+
+    expect(cleanRequirementText(input, defaultCleanRules)).toBe('用户点击领取后，系统需要判断库存。');
+  });
+
+  it('preserves markdown table lines', () => {
+    const input = `| 字段 | 说明 |\n| --- | --- |\n| mobile | 手机号 |`;
+
+    expect(cleanRequirementText(input, defaultCleanRules)).toBe(input);
+  });
+});
+
+describe('requirement input file utilities', () => {
+  it('detects supported file types from extension', () => {
+    expect(getFileType('需求.docx')).toBe('word');
+    expect(getFileType('说明.pdf')).toBe('pdf');
+    expect(getFileType('规则.md')).toBe('markdown');
+    expect(getFileType('数据.xlsx')).toBe('excel');
+    expect(getFileType('备注.txt')).toBe('txt');
+    expect(getFileType('unknown.zip')).toBe('unknown');
+  });
+
+  it('formats file size for upload list', () => {
+    expect(formatFileSize(512)).toBe('512 B');
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+    expect(formatFileSize(1024 * 1024)).toBe('1.00 MB');
+  });
+});

--- a/src/lib/requirementInput.ts
+++ b/src/lib/requirementInput.ts
@@ -1,0 +1,278 @@
+export type RequirementType =
+  | '功能需求'
+  | '接口需求'
+  | '页面交互需求'
+  | '后台管理需求'
+  | '数据报表需求'
+  | '活动营销需求'
+  | '库存/交易类需求';
+
+export type GenerateTarget =
+  | '生成测试点'
+  | '生成测试用例'
+  | '生成需求疑问'
+  | '生成风险点'
+  | '完整测试分析';
+
+export type UploadedFileStatus = '上传成功' | '上传失败' | '等待解析';
+export type UploadedFileType = 'word' | 'pdf' | 'markdown' | 'excel' | 'txt' | 'unknown';
+export type RequirementInputMode = 'upload' | 'text';
+export type ParseStatus = 'idle' | 'parsing' | 'success' | 'error';
+
+export interface UploadedFileItem {
+  id: string;
+  name: string;
+  size: string;
+  status: UploadedFileStatus;
+  type: UploadedFileType;
+}
+
+export interface CleanRules {
+  removeEmptyLines: boolean;
+  removeExtraSpaces: boolean;
+  removeGarbledChars: boolean;
+  keepHeadingLevel: boolean;
+  keepTableContent: boolean;
+  mergeAbnormalLineBreaks: boolean;
+}
+
+export interface RequirementDraft {
+  projectName: string;
+  requirementName: string;
+  requirementType: RequirementType;
+  generateTarget: GenerateTarget;
+  inputMode: RequirementInputMode;
+  requirementText: string;
+  cleanRules: CleanRules;
+}
+
+export interface RequirementInputState extends RequirementDraft {
+  uploadedFiles: UploadedFileItem[];
+  rawContent: string;
+  cleanedContent: string;
+  parseStep: number;
+  parseStatus: ParseStatus;
+}
+
+export const REQUIREMENT_DRAFT_STORAGE_KEY = 'requirement-input-parse-draft';
+
+export const requirementTypeOptions: RequirementType[] = [
+  '功能需求',
+  '接口需求',
+  '页面交互需求',
+  '后台管理需求',
+  '数据报表需求',
+  '活动营销需求',
+  '库存/交易类需求',
+];
+
+export const generateTargetOptions: GenerateTarget[] = [
+  '生成测试点',
+  '生成测试用例',
+  '生成需求疑问',
+  '生成风险点',
+  '完整测试分析',
+];
+
+export const defaultCleanRules: CleanRules = {
+  removeEmptyLines: true,
+  removeExtraSpaces: true,
+  removeGarbledChars: true,
+  keepHeadingLevel: true,
+  keepTableContent: true,
+  mergeAbnormalLineBreaks: true,
+};
+
+export const sampleRequirementText = `1. 项目概述
+本需求文档描述了电商平台会员中心的功能需求，旨在提升用户管理能力与购物体验。
+
+2. 功能需求
+2.1 会员注册
+- 用户可通过手机号、邮箱进行注册。
+- 注册时需填写验证码，验证码有效期为 5 分钟。
+- 注册成功后自动登录并跳转至个人中心。
+
+2.2 登录与登出
+- 支持账号密码登录。
+- 支持短信验证码登录。
+- 用户可主动退出登录。`;
+
+export const mockUploadedFiles: UploadedFileItem[] = [
+  {
+    id: 'mock-docx-1',
+    name: '电商平台需求规格说明书_v2.1.docx',
+    size: '1.24 MB',
+    status: '上传成功',
+    type: 'word',
+  },
+  {
+    id: 'mock-pdf-1',
+    name: '会员中心功能需求补充说明.pdf',
+    size: '856 KB',
+    status: '上传成功',
+    type: 'pdf',
+  },
+];
+
+export const initialRequirementInputState: RequirementInputState = {
+  projectName: '电商平台 3.0 版本',
+  requirementName: '会员中心功能需求',
+  requirementType: '功能需求',
+  generateTarget: '生成测试用例',
+  inputMode: 'upload',
+  requirementText: sampleRequirementText,
+  uploadedFiles: mockUploadedFiles,
+  cleanRules: defaultCleanRules,
+  rawContent: '',
+  cleanedContent: '',
+  parseStep: -1,
+  parseStatus: 'idle',
+};
+
+const headingPattern = /^\s*((\d+(\.\d+)*[.、]?)|([一二三四五六七八九十]+[、.])|(（[一二三四五六七八九十]+）)|(\([一二三四五六七八九十]+\)))\s*/;
+const listPattern = /^\s*[-*•]\s+/;
+const tablePattern = /\|/;
+const terminalPunctuationPattern = /[。！？!?；;：:]$/;
+
+function shouldPreserveLineBreak(previousLine: string, nextLine: string, rules: CleanRules): boolean {
+  if (!previousLine.trim() || !nextLine.trim()) {
+    return true;
+  }
+
+  if (rules.keepHeadingLevel && (headingPattern.test(previousLine) || headingPattern.test(nextLine))) {
+    return true;
+  }
+
+  if (listPattern.test(previousLine) || listPattern.test(nextLine)) {
+    return true;
+  }
+
+  if (rules.keepTableContent && (tablePattern.test(previousLine) || tablePattern.test(nextLine))) {
+    return true;
+  }
+
+  return terminalPunctuationPattern.test(previousLine.trim());
+}
+
+function mergeAbnormalLineBreaks(input: string, rules: CleanRules): string {
+  const lines = input.split('\n');
+  const merged: string[] = [];
+
+  for (const line of lines) {
+    const currentLine = line.trimEnd();
+    const previousLine = merged[merged.length - 1];
+
+    if (previousLine === undefined || shouldPreserveLineBreak(previousLine, currentLine, rules)) {
+      merged.push(currentLine);
+    } else {
+      const connector = /[，,]$/.test(previousLine.trimEnd()) ? '' : '，';
+      merged[merged.length - 1] = `${previousLine.trimEnd()}${connector}${currentLine.trimStart()}`;
+    }
+  }
+
+  return merged.join('\n');
+}
+
+export function cleanRequirementText(input: string, rules: CleanRules): string {
+  let output = input.replace(/\r\n?/g, '\n');
+
+  if (rules.removeGarbledChars) {
+    output = output.replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '');
+  }
+
+  if (rules.removeExtraSpaces) {
+    output = output
+      .split('\n')
+      .map((line) => {
+        if (rules.keepTableContent && tablePattern.test(line)) {
+          return line.trim();
+        }
+
+        return line.replace(/[ \t]{2,}/g, ' ').trim();
+      })
+      .join('\n');
+  }
+
+  if (rules.mergeAbnormalLineBreaks) {
+    output = mergeAbnormalLineBreaks(output, rules);
+  }
+
+  if (rules.removeEmptyLines) {
+    output = output
+      .split('\n')
+      .filter((line) => line.trim().length > 0)
+      .join('\n');
+  }
+
+  return output.trim();
+}
+
+export function getFileType(fileName: string): UploadedFileType {
+  const extension = fileName.split('.').pop()?.toLowerCase() ?? '';
+
+  if (extension === 'doc' || extension === 'docx') return 'word';
+  if (extension === 'pdf') return 'pdf';
+  if (extension === 'md') return 'markdown';
+  if (extension === 'xls' || extension === 'xlsx') return 'excel';
+  if (extension === 'txt') return 'txt';
+
+  return 'unknown';
+}
+
+export function formatFileSize(sizeInBytes: number): string {
+  if (sizeInBytes < 1024) {
+    return `${sizeInBytes} B`;
+  }
+
+  const sizeInKb = sizeInBytes / 1024;
+  if (sizeInKb < 1024) {
+    return `${sizeInKb.toFixed(sizeInKb >= 100 ? 0 : 1)} KB`;
+  }
+
+  const sizeInMb = sizeInKb / 1024;
+  return `${sizeInMb.toFixed(2)} MB`;
+}
+
+function isCleanRules(value: unknown): value is CleanRules {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const rules = value as Partial<Record<keyof CleanRules, unknown>>;
+  return Object.keys(defaultCleanRules).every((key) => typeof rules[key as keyof CleanRules] === 'boolean');
+}
+
+function isRequirementDraft(value: unknown): value is RequirementDraft {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const draft = value as Partial<RequirementDraft>;
+  return (
+    typeof draft.projectName === 'string' &&
+    typeof draft.requirementName === 'string' &&
+    requirementTypeOptions.includes(draft.requirementType as RequirementType) &&
+    generateTargetOptions.includes(draft.generateTarget as GenerateTarget) &&
+    (draft.inputMode === 'upload' || draft.inputMode === 'text') &&
+    typeof draft.requirementText === 'string' &&
+    isCleanRules(draft.cleanRules)
+  );
+}
+
+export function loadDraftFromStorage(storage: Storage = window.localStorage): RequirementDraft | null {
+  try {
+    const rawDraft = storage.getItem(REQUIREMENT_DRAFT_STORAGE_KEY);
+    if (!rawDraft) {
+      return null;
+    }
+
+    const parsedDraft: unknown = JSON.parse(rawDraft);
+    return isRequirementDraft(parsedDraft) ? parsedDraft : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDraftToStorage(draft: RequirementDraft, storage: Storage = window.localStorage): void {
+  storage.setItem(REQUIREMENT_DRAFT_STORAGE_KEY, JSON.stringify(draft));
+}

--- a/src/pages/ai-workbench/components/WorkbenchHeader.tsx
+++ b/src/pages/ai-workbench/components/WorkbenchHeader.tsx
@@ -1,0 +1,44 @@
+import { type ReactNode } from 'react';
+import { BrainCircuit, FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface WorkbenchHeaderProps {
+  title: string;
+  saveStateText: string;
+  remoteStatusText: string;
+  onOpenRequirement: () => void;
+  titleIcon?: ReactNode;
+}
+
+export function WorkbenchHeader({
+  title,
+  saveStateText,
+  remoteStatusText,
+  onOpenRequirement,
+  titleIcon,
+}: WorkbenchHeaderProps) {
+  return (
+    <header className="shrink-0 h-12 flex items-center justify-between px-4 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+      <div className="flex items-center gap-2.5">
+        <div className="p-1.5 rounded-md bg-indigo-500/10 text-indigo-600 dark:text-indigo-300">
+          {titleIcon ?? <BrainCircuit className="h-4 w-4" />}
+        </div>
+        <h1 className="text-sm font-semibold text-slate-900 dark:text-white">{title}</h1>
+      </div>
+      <div className="flex items-center gap-3 text-xs text-slate-500 dark:text-slate-400">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 px-2 text-xs gap-1.5 text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-white"
+          onClick={onOpenRequirement}
+        >
+          <FileText className="h-3.5 w-3.5" />
+          <span>需求信息</span>
+        </Button>
+        <span>{saveStateText}</span>
+        <span>{remoteStatusText}</span>
+      </div>
+    </header>
+  );
+}

--- a/src/pages/ai-workbench/components/WorkbenchSidebar.tsx
+++ b/src/pages/ai-workbench/components/WorkbenchSidebar.tsx
@@ -1,0 +1,431 @@
+import { type ChangeEvent, type ReactNode, useCallback, useEffect, useState } from 'react';
+import {
+  CheckCircle2, ChevronDown, Circle, Clock3, Download,
+  FileText, History, ImageIcon, Loader2, PauseCircle,
+  RotateCcw, ShieldAlert, Upload, XCircle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { toast } from 'sonner';
+import { aiCasesApi, type AiCaseWorkspaceSummary } from '@/api';
+import { exportMindDataToMarkdown, downloadTextFile } from '@/lib/aiCaseStorage';
+import type {
+  AiCaseAttachmentPreview, AiCaseMindData, AiCaseNode,
+  AiCaseNodeStatus, AiCaseProgress,
+} from '@/types/aiCases';
+
+const STATUS_ACTIONS: Array<{
+  status: AiCaseNodeStatus; label: string; icon: ReactNode;
+  activeClass: string; idleClass: string;
+}> = [
+  { status: 'todo', label: '待执行', icon: <Circle className="h-3.5 w-3.5" />,
+    activeClass: 'border-slate-400 bg-slate-100 text-slate-700 dark:border-slate-500 dark:bg-slate-700 dark:text-slate-200',
+    idleClass: 'border-slate-200 text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800' },
+  { status: 'doing', label: '执行中', icon: <Clock3 className="h-3.5 w-3.5" />,
+    activeClass: 'border-blue-400 bg-blue-100 text-blue-700 dark:border-blue-500 dark:bg-blue-900/30 dark:text-blue-300',
+    idleClass: 'border-slate-200 text-slate-600 hover:bg-blue-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-blue-900/20' },
+  { status: 'blocked', label: '阻塞', icon: <ShieldAlert className="h-3.5 w-3.5" />,
+    activeClass: 'border-amber-400 bg-amber-100 text-amber-700 dark:border-amber-500 dark:bg-amber-900/30 dark:text-amber-300',
+    idleClass: 'border-slate-200 text-slate-600 hover:bg-amber-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-amber-900/20' },
+  { status: 'passed', label: '通过', icon: <CheckCircle2 className="h-3.5 w-3.5" />,
+    activeClass: 'border-emerald-400 bg-emerald-100 text-emerald-700 dark:border-emerald-500 dark:bg-emerald-900/30 dark:text-emerald-300',
+    idleClass: 'border-slate-200 text-slate-600 hover:bg-emerald-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-emerald-900/20' },
+  { status: 'failed', label: '失败', icon: <XCircle className="h-3.5 w-3.5" />,
+    activeClass: 'border-rose-400 bg-rose-100 text-rose-700 dark:border-rose-500 dark:bg-rose-900/30 dark:text-rose-300',
+    idleClass: 'border-slate-200 text-slate-600 hover:bg-rose-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-rose-900/20' },
+  { status: 'skipped', label: '跳过', icon: <PauseCircle className="h-3.5 w-3.5" />,
+    activeClass: 'border-purple-400 bg-purple-100 text-purple-700 dark:border-purple-500 dark:bg-purple-900/30 dark:text-purple-300',
+    idleClass: 'border-slate-200 text-slate-600 hover:bg-purple-50 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-purple-900/20' },
+];
+
+const PROGRESS_METRICS: Array<{ key: keyof AiCaseProgress; label: string; color: string; dotClass: string }> = [
+  { key: 'passed',  label: '通过',  color: '#10b981', dotClass: 'bg-emerald-500' },
+  { key: 'failed',  label: '失败',  color: '#f43f5e', dotClass: 'bg-rose-500'    },
+  { key: 'doing',   label: '执行中', color: '#3b82f6', dotClass: 'bg-blue-500'   },
+  { key: 'blocked', label: '阻塞',  color: '#f59e0b', dotClass: 'bg-amber-500'   },
+  { key: 'skipped', label: '跳过',  color: '#a855f7', dotClass: 'bg-purple-500'  },
+  { key: 'todo',    label: '待执行', color: '#94a3b8', dotClass: 'bg-slate-400'  },
+];
+
+function SidebarSection({
+  title, icon, defaultOpen = true, highlight, badge, children,
+}: {
+  title: string; icon: ReactNode; defaultOpen?: boolean;
+  highlight?: boolean; badge?: number; children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border-b border-slate-100 dark:border-slate-800 last:border-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`w-full flex items-center justify-between px-4 py-2.5 text-left transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 ${highlight ? 'bg-indigo-50/40 dark:bg-indigo-900/10' : ''}`}
+      >
+        <span className={`flex items-center gap-2 text-xs font-semibold uppercase tracking-wide ${highlight ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-500 dark:text-slate-400'}`}>
+          {icon}
+          {title}
+          {typeof badge === 'number' && badge > 0
+            ? <span className="ml-0.5 inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-indigo-500 px-1 text-[9px] font-bold text-white">{badge}</span>
+            : null}
+        </span>
+        <ChevronDown className={`h-3.5 w-3.5 text-slate-400 transition-transform duration-200 ${open ? '' : '-rotate-90'}`} />
+      </button>
+      {open ? <div className="px-4 pb-4">{children}</div> : null}
+    </div>
+  );
+}
+
+function DonutChart({ progress }: { progress: AiCaseProgress }) {
+  const SIZE = 88; const STROKE = 10;
+  const RADIUS = (SIZE - STROKE) / 2;
+  const CIRC = 2 * Math.PI * RADIUS;
+  const total = Math.max(progress.total, 1);
+  type Seg = { key: keyof AiCaseProgress; color: string; dotClass: string; label: string; value: number; dash: number; offset: number };
+  const segs: Seg[] = [];
+  let acc = 0;
+  for (const m of PROGRESS_METRICS) {
+    const value = progress[m.key] as number;
+    if (value <= 0) continue;
+    const dash = (value / total) * CIRC;
+    segs.push({ ...m, value, dash, offset: CIRC - acc });
+    acc += dash;
+  }
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative shrink-0">
+        <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`} className="-rotate-90">
+          <circle cx={SIZE / 2} cy={SIZE / 2} r={RADIUS} fill="none" stroke="currentColor" strokeWidth={STROKE} className="text-slate-100 dark:text-slate-800" />
+          {segs.map((s) => (
+            <circle key={String(s.key)} cx={SIZE / 2} cy={SIZE / 2} r={RADIUS} fill="none" stroke={s.color} strokeWidth={STROKE}
+              strokeDasharray={`${s.dash} ${CIRC - s.dash}`} strokeDashoffset={s.offset} />
+          ))}
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-base font-bold text-slate-800 dark:text-white leading-none tabular-nums">{progress.completionRate}%</span>
+          <span className="text-[9px] text-slate-400 mt-0.5">完成率</span>
+        </div>
+      </div>
+      <div className="flex-1 grid grid-cols-2 gap-x-2 gap-y-1.5">
+        <div className="col-span-2 text-[11px] text-slate-500 mb-0.5">
+          共 <span className="font-semibold text-slate-700 dark:text-white">{progress.total}</span> 个测试点
+        </div>
+        {PROGRESS_METRICS.map((m) => (
+          <div key={String(m.key)} className="flex items-center gap-1.5 text-[11px] text-slate-600 dark:text-slate-400">
+            <span className={`h-1.5 w-1.5 rounded-full shrink-0 ${m.dotClass}`} />
+            <span className="truncate">{m.label}</span>
+            <span className="ml-auto font-semibold text-slate-700 dark:text-slate-200 tabular-nums">{progress[m.key] as number}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HistoryWorkspaceList({
+  onLoadWorkspace, currentRemoteId,
+}: {
+  onLoadWorkspace: (id: number) => void;
+  currentRemoteId: number | null;
+}) {
+  const [list, setList] = useState<AiCaseWorkspaceSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    try { const res = await aiCasesApi.listWorkspaces({ limit: 10 }); setList(res.data ?? []); }
+    catch { toast.error('获取历史工作台失败'); }
+    finally { setIsLoading(false); }
+  }, []);
+  useEffect(() => { if (expanded) void load(); }, [expanded, load]);
+
+  if (!expanded) {
+    return (
+      <button type="button" onClick={() => setExpanded(true)}
+        className="flex items-center gap-1.5 text-xs text-indigo-600 dark:text-indigo-400 hover:underline underline-offset-2">
+        <History className="h-3.5 w-3.5" />查看历史工作台记录
+      </button>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] text-slate-500">最近 10 条</span>
+        <button type="button" onClick={() => void load()}
+          className="text-[11px] text-indigo-600 dark:text-indigo-400 hover:underline flex items-center gap-1" disabled={isLoading}>
+          {isLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : '刷新'}
+        </button>
+      </div>
+      {isLoading && list.length === 0 ? (
+        <div className="flex items-center gap-1.5 py-2 text-[11px] text-slate-400"><Loader2 className="h-3.5 w-3.5 animate-spin" />加载中...</div>
+      ) : list.length === 0 ? (
+        <div className="text-[11px] text-slate-400 py-2">暂无远端工作台记录</div>
+      ) : (
+        <div className="space-y-1.5 max-h-52 overflow-y-auto pr-0.5">
+          {list.map((item) => (
+            <button key={item.id} type="button" onClick={() => onLoadWorkspace(item.id)}
+              className={`w-full text-left rounded-md border px-2.5 py-2 text-[11px] transition-colors ${
+                currentRemoteId === item.id
+                  ? 'border-indigo-300 bg-indigo-50 dark:border-indigo-500/60 dark:bg-indigo-900/20'
+                  : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 hover:border-indigo-300 hover:bg-indigo-50/60 dark:hover:bg-indigo-900/10'
+              }`}>
+              <div className="flex items-start justify-between gap-1">
+                <span className="font-medium text-slate-800 dark:text-slate-100 truncate flex-1">{item.name}</span>
+                <span className={`shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                  item.status === 'published' ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400'
+                  : item.status === 'archived' ? 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400'
+                  : 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'}`}>
+                  {item.status === 'published' ? '已发布' : item.status === 'archived' ? '已归档' : '草稿'}
+                </span>
+              </div>
+              <div className="text-slate-400 mt-0.5">{item.counters.totalCases} 个用例 · v{item.version}</div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export interface WorkbenchSidebarProps {
+  isGenerating: boolean; generationProgress: number; generationStageText: string; onGenerate: () => void;
+  progress: AiCaseProgress;
+  selectedNode: AiCaseNode | null; selectedNodeStatus: AiCaseNodeStatus;
+  canEditSelectedNode: boolean;
+  /** 多选模式：是否有选中的 testcase 节点（决定按钮是否 disabled） */
+  canEditAnySelectedNode: boolean;
+  /** 是否处于多选状态（选中了 2 个以上节点） */
+  isMultiSelect: boolean;
+  /** 多选中可操作的 testcase 节点数量 */
+  selectedTestcaseCount: number;
+  isUpdatingNodeStatus: boolean; onStatusChange: (status: AiCaseNodeStatus) => void;
+  attachments: AiCaseAttachmentPreview[]; isUploading: boolean;
+  onUploadAttachment: (event: ChangeEvent<HTMLInputElement>) => void; onDeleteAttachment: (id: string) => void;
+  isRemoteLinked: boolean; remoteWorkspaceId: number | null;
+  isPublishingRemote: boolean; isSyncingRemote: boolean;
+  onPublishRemote: () => void; onSyncFromRemote: () => void;
+  onResetTemplate: () => void; onLoadHistoryWorkspace: (id: number) => void;
+  mindData: AiCaseMindData | null;
+}
+
+export function WorkbenchSidebar({
+  isGenerating, generationProgress: _generationProgress, generationStageText: _generationStageText, onGenerate: _onGenerate, progress,
+  selectedNode, selectedNodeStatus, canEditSelectedNode,
+  canEditAnySelectedNode, isMultiSelect, selectedTestcaseCount,
+  isUpdatingNodeStatus, onStatusChange,
+  attachments, isUploading, onUploadAttachment, onDeleteAttachment,
+  isRemoteLinked, remoteWorkspaceId, isPublishingRemote, isSyncingRemote,
+  onPublishRemote, onSyncFromRemote, onResetTemplate, onLoadHistoryWorkspace, mindData,
+}: WorkbenchSidebarProps) {
+  const isBusy = isGenerating || isPublishingRemote || isSyncingRemote;
+  const hasSelectedNode = Boolean(selectedNode);
+  const selectedNodeLabel = selectedNode?.topic ?? '未选中节点';
+
+  const handleExportMarkdown = useCallback(() => {
+    if (!mindData) { toast.error('结果数据尚未加载，无法导出'); return; }
+    const md = exportMindDataToMarkdown(mindData);
+    const safeTitle = (mindData.nodeData.topic || 'AI-Testcase').replace(/[^a-zA-Z0-9\u4e00-\u9fa5_-]/g, '_');
+    downloadTextFile(md, `${safeTitle}.md`);
+    toast.success('测试用例已导出为 Markdown');
+  }, [mindData]);
+
+  return (
+    <aside className="flex flex-col bg-white dark:bg-slate-900">
+
+      {/* ══ 执行进度 ══════════════════════════════════════ */}
+      <SidebarSection title="执行进度" icon={<CheckCircle2 className="h-3.5 w-3.5" />} defaultOpen={true}>
+        {progress.total === 0 ? (
+          <p className="text-[11px] text-slate-400 py-1">AI 生成后此处显示进度统计</p>
+        ) : (
+          <div className="space-y-3">
+            <DonutChart progress={progress} />
+            <div>
+              <div className="flex items-center justify-between text-[11px] text-slate-500 mb-1">
+                <span>整体进度</span>
+                <span className="font-medium text-slate-700 dark:text-slate-200">{progress.done} / {progress.total}</span>
+              </div>
+              <Progress value={progress.completionRate} className="h-1.5 bg-slate-100 dark:bg-slate-800 [&>div]:bg-emerald-500" />
+            </div>
+          </div>
+        )}
+
+        {/* ── 状态操作按钮 ── */}
+        <div className="mt-3 pt-3 border-t border-slate-100 dark:border-slate-800 space-y-3">
+          <div className="grid grid-cols-3 gap-1.5">
+            {STATUS_ACTIONS.map((item) => {
+              const isActive = !isMultiSelect && hasSelectedNode && selectedNodeStatus === item.status;
+              const isDisabled = !(isMultiSelect ? canEditAnySelectedNode : canEditSelectedNode) || isUpdatingNodeStatus;
+              return (
+                <button key={item.status} type="button"
+                  onClick={() => void onStatusChange(item.status)}
+                  disabled={isDisabled}
+                  className={`h-8 rounded-md border text-xs font-medium flex items-center justify-center gap-1 transition-all disabled:opacity-40 disabled:cursor-not-allowed ${isActive ? `${item.activeClass} ring-2 ring-inset ring-indigo-300 dark:ring-indigo-600` : item.idleClass}`}>
+                  {isUpdatingNodeStatus && isActive ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : item.icon}
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+          {/* 多选批量操作加载提示 */}
+          {isMultiSelect && isUpdatingNodeStatus && (
+            <div className="flex items-center gap-1.5 text-[11px] text-indigo-600 dark:text-indigo-400">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              <span>正在批量更新节点状态...</span>
+            </div>
+          )}
+
+          {/* ── 节点说明 ── */}
+          <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/60 p-2.5">
+            {/* 多选提示 banner */}
+            {isMultiSelect ? (
+              <div className="flex items-center gap-1.5 mb-2">
+                <span className="text-[10px] uppercase tracking-wide text-indigo-500 font-semibold">多选模式</span>
+                <span className="text-[10px] text-slate-500">
+                  {selectedTestcaseCount > 0
+                    ? `${selectedTestcaseCount} 个测试点可批量操作`
+                    : '当前选中节点无测试点'}
+                </span>
+              </div>
+            ) : (
+              <div className="text-[10px] uppercase tracking-wide text-slate-400 font-medium mb-1">节点说明</div>
+            )}
+            {hasSelectedNode ? (
+              <>
+                <p className="text-sm font-medium text-slate-800 dark:text-white break-words leading-snug">{selectedNodeLabel}</p>
+                <div className="mt-1.5 flex items-center gap-2 flex-wrap">
+                  {(() => {
+                    const a = STATUS_ACTIONS.find((x) => x.status === selectedNodeStatus);
+                    if (!a) return null;
+                    return <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded border ${a.activeClass}`}>{a.icon}{a.label}</span>;
+                  })()}
+                  {!canEditSelectedNode && !isMultiSelect ? <span className="text-[10px] text-slate-400">（仅测试点可切换状态）</span> : null}
+                </div>
+                {/* 展示 testcase 的链式子节点（前置条件→测试步骤→预期结果），仅单选时显示 */}
+                {canEditSelectedNode && !isMultiSelect ? (() => {
+                  const preconditionNode = (selectedNode?.children as AiCaseNode[] | undefined)?.[0];
+                  const stepsNode = (preconditionNode?.children as AiCaseNode[] | undefined)?.[0];
+                  const expectedNode = (stepsNode?.children as AiCaseNode[] | undefined)?.[0];
+
+                  const sections: Array<{ label: string; topic: string; colorClass: string }> = [];
+                  if (preconditionNode?.topic) {
+                    sections.push({ label: '前置条件', topic: preconditionNode.topic.trim(), colorClass: 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400' });
+                  }
+                  if (stepsNode?.topic) {
+                    sections.push({ label: '测试步骤', topic: stepsNode.topic.trim(), colorClass: 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400' });
+                  }
+                  if (expectedNode?.topic) {
+                    sections.push({ label: '预期结果', topic: expectedNode.topic.trim(), colorClass: 'bg-pink-50 text-pink-700 dark:bg-pink-900/20 dark:text-pink-400' });
+                  }
+
+                  // 兼容仅有 note 的旧格式
+                  if (sections.length === 0 && selectedNode?.note) {
+                    const labelColors: Record<string, string> = {
+                      '前置条件': 'bg-yellow-50 text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400',
+                      '测试步骤': 'bg-blue-50 text-blue-700 dark:bg-blue-900/20 dark:text-blue-400',
+                      '预期结果': 'bg-pink-50 text-pink-700 dark:bg-pink-900/20 dark:text-pink-400',
+                    };
+                    return (
+                      <div className="mt-2 space-y-1">
+                        {selectedNode.note.split(/\r?\n/).map((line, idx) => {
+                          const trimmed = line.trim();
+                          if (!trimmed) return null;
+                          const m = trimmed.match(/^(前置条件|测试步骤|预期结果)[：:]\s*([\s\S]*)$/);
+                          if (m) {
+                            return (
+                              <div key={idx} className="rounded-md p-1.5">
+                                <span className={`inline-block text-[10px] font-semibold px-1.5 py-0.5 rounded mb-0.5 ${labelColors[m[1]] ?? 'bg-slate-50 text-slate-600'}`}>{m[1]}</span>
+                                <p className="text-[11px] text-slate-600 dark:text-slate-400 whitespace-pre-wrap leading-relaxed">{m[2]}</p>
+                              </div>
+                            );
+                          }
+                          return <p key={idx} className="text-[11px] text-slate-500 whitespace-pre-wrap">{trimmed}</p>;
+                        })}
+                      </div>
+                    );
+                  }
+
+                  if (sections.length === 0) return null;
+                  return (
+                    <div className="mt-2 space-y-1">
+                      {sections.map((s, idx) => (
+                        <div key={idx} className="rounded-md p-1.5">
+                          <span className={`inline-block text-[10px] font-semibold px-1.5 py-0.5 rounded mb-0.5 ${s.colorClass}`}>{s.label}</span>
+                          <p className="text-[11px] text-slate-600 dark:text-slate-400 whitespace-pre-wrap leading-relaxed">{s.topic}</p>
+                        </div>
+                      ))}
+                    </div>
+                  );
+                })() : null}
+              </>
+            ) : (
+              <p className="text-[11px] text-slate-400">请先在列表中选择一个测试点</p>
+            )}
+          </div>
+        </div>
+      </SidebarSection>
+
+      {/* ══ 执行记录 ══════════════════════════════════════ */}
+      <SidebarSection title="执行记录" icon={<ImageIcon className="h-3.5 w-3.5" />} defaultOpen={false} badge={attachments.length} highlight={attachments.length > 0}>
+        <div className="space-y-2.5">
+          <label className={`flex items-center gap-2 cursor-pointer ${!canEditSelectedNode || isUploading ? 'opacity-50 pointer-events-none' : ''}`}>
+            <span className="inline-flex h-8 items-center gap-1.5 rounded-md border border-dashed border-slate-300 dark:border-slate-600 px-3 text-xs text-slate-600 dark:text-slate-400 hover:border-indigo-400 hover:text-indigo-600 transition-colors">
+              {isUploading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
+              {isUploading ? '上传中...' : '上传截图'}
+            </span>
+            <input type="file" accept="image/*" multiple className="hidden" onChange={onUploadAttachment} disabled={!canEditSelectedNode || isUploading} />
+          </label>
+          <p className="text-[10px] text-slate-400">支持 Ctrl/Cmd + V 直接粘贴截图</p>
+          {attachments.length === 0 ? (
+            <p className="text-[11px] text-slate-400">当前节点暂无截图</p>
+          ) : (
+            <div className="space-y-1.5 max-h-48 overflow-y-auto pr-0.5">
+              {attachments.map((att) => (
+                <div key={att.id} className="flex items-center gap-2 rounded-md border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/40 p-2">
+                  <a href={att.previewUrl} target="_blank" rel="noreferrer" className="shrink-0">
+                    <img src={att.previewUrl} alt={att.name} className="h-9 w-9 rounded object-cover border border-slate-200 dark:border-slate-700" />
+                  </a>
+                  <div className="min-w-0 flex-1">
+                    <a href={att.previewUrl} target="_blank" rel="noreferrer" className="block text-xs font-medium truncate text-slate-700 dark:text-slate-200 hover:text-indigo-600">{att.name}</a>
+                    <span className="text-[10px] text-slate-400">{Math.round(att.size / 1024)} KB</span>
+                  </div>
+                  <button type="button" className="shrink-0 text-slate-400 hover:text-rose-500 transition-colors" onClick={() => onDeleteAttachment(att.id)} aria-label="删除截图">
+                    <XCircle className="h-4 w-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </SidebarSection>
+
+      {/* ══ 工作台操作 ════════════════════════════════════ */}
+      <SidebarSection title="工作台操作" icon={<Download className="h-3.5 w-3.5" />} defaultOpen={false}>
+        <div className="space-y-2">
+          <Button variant="outline" size="sm" className="w-full gap-1.5 justify-start text-xs" onClick={onPublishRemote} disabled={isPublishingRemote || isBusy}>
+            {isPublishingRemote ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
+            {isRemoteLinked ? '同步到远端' : '发布到远端'}
+          </Button>
+          <Button variant="outline" size="sm" className="w-full gap-1.5 justify-start text-xs" onClick={onSyncFromRemote} disabled={!isRemoteLinked || isSyncingRemote || isBusy}>
+            {isSyncingRemote ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+            从远端拉取
+          </Button>
+          <Button variant="outline" size="sm" className="w-full gap-1.5 justify-start text-xs" onClick={onResetTemplate} disabled={isBusy}>
+            <RotateCcw className="h-3.5 w-3.5" />
+            重置模板
+          </Button>
+          <div className="pt-1 border-t border-slate-100 dark:border-slate-800">
+            <Button variant="outline" size="sm" className="w-full gap-1.5 justify-start text-xs" onClick={handleExportMarkdown} disabled={!mindData}>
+              <FileText className="h-3.5 w-3.5" />
+              导出 Markdown
+            </Button>
+          </div>
+        </div>
+      </SidebarSection>
+
+      {/* ══ 历史工作台 ════════════════════════════════════ */}
+      <SidebarSection title="历史工作台" icon={<History className="h-3.5 w-3.5" />} defaultOpen={false}>
+        <HistoryWorkspaceList onLoadWorkspace={onLoadHistoryWorkspace} currentRemoteId={remoteWorkspaceId} />
+      </SidebarSection>
+
+    </aside>
+  );
+}

--- a/src/pages/ai-workbench/components/WorkbenchSummaryBar.tsx
+++ b/src/pages/ai-workbench/components/WorkbenchSummaryBar.tsx
@@ -1,0 +1,40 @@
+interface WorkbenchSummaryItem {
+  label: string;
+  value: string;
+  hint: string;
+}
+
+interface WorkbenchSummaryBarProps {
+  items: WorkbenchSummaryItem[];
+  gridClassName?: string;
+}
+
+function SummaryCard({ label, value, hint }: WorkbenchSummaryItem) {
+  return (
+    <div className="rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-4 py-3">
+      <div className="text-xs font-medium text-slate-500 dark:text-slate-400">{label}</div>
+      <div className="mt-1 text-xl font-semibold text-slate-900 dark:text-white">{value}</div>
+      <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</div>
+    </div>
+  );
+}
+
+export function WorkbenchSummaryBar({
+  items,
+  gridClassName = 'grid-cols-5',
+}: WorkbenchSummaryBarProps) {
+  return (
+    <div className="shrink-0 border-b border-slate-200 dark:border-slate-800 bg-slate-50/80 dark:bg-slate-950 px-4 py-3">
+      <div className={`grid gap-3 ${gridClassName}`}>
+        {items.map((item) => (
+          <SummaryCard
+            key={item.label}
+            label={item.label}
+            value={item.value}
+            hint={item.hint}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ai-workbench/components/WorkbenchTabs.tsx
+++ b/src/pages/ai-workbench/components/WorkbenchTabs.tsx
@@ -1,0 +1,71 @@
+import { type ReactNode } from 'react';
+
+export interface WorkbenchTabItem<TTab extends string = string> {
+  id: TTab;
+  label: string;
+  description: string;
+  icon: ReactNode;
+}
+
+interface WorkbenchTabsProps<TTab extends string> {
+  activeTab: TTab;
+  items: Array<WorkbenchTabItem<TTab>>;
+  onChange: (tab: TTab) => void;
+}
+
+function TabButton({
+  active,
+  icon,
+  label,
+  description,
+  onClick,
+}: {
+  active: boolean;
+  icon: ReactNode;
+  label: string;
+  description: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`min-w-[180px] rounded-xl border px-4 py-3 text-left transition-colors ${
+        active
+          ? 'border-indigo-300 bg-indigo-50 text-indigo-700 dark:border-indigo-500/60 dark:bg-indigo-500/10 dark:text-indigo-300'
+          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:bg-slate-800/80'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <span className={active ? '' : 'text-slate-400 dark:text-slate-500'}>{icon}</span>
+        <span className="text-sm font-semibold">{label}</span>
+      </div>
+      <div className={`mt-1 text-xs ${active ? 'text-indigo-600/80 dark:text-indigo-300/80' : 'text-slate-500 dark:text-slate-400'}`}>
+        {description}
+      </div>
+    </button>
+  );
+}
+
+export function WorkbenchTabs<TTab extends string>({
+  activeTab,
+  items,
+  onChange,
+}: WorkbenchTabsProps<TTab>) {
+  return (
+    <div className="shrink-0 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 px-4 py-3">
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {items.map((tab) => (
+          <TabButton
+            key={tab.id}
+            active={activeTab === tab.id}
+            icon={tab.icon}
+            label={tab.label}
+            description={tab.description}
+            onClick={() => onChange(tab.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -1,0 +1,221 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Play, RefreshCw, Save } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import CleanRulesPanel from '@/pages/cases/components/CleanRulesPanel';
+import ParseProgressSteps from '@/pages/cases/components/ParseProgressSteps';
+import RequirementConfigForm from '@/pages/cases/components/RequirementConfigForm';
+import RequirementContentCompare from '@/pages/cases/components/RequirementContentCompare';
+import RequirementTextEditor from '@/pages/cases/components/RequirementTextEditor';
+import RequirementUploadPanel from '@/pages/cases/components/RequirementUploadPanel';
+import UploadedFileList from '@/pages/cases/components/UploadedFileList';
+import type { CleanRules, GenerateTarget, RequirementInputMode, RequirementInputState, RequirementType, UploadedFileItem } from '@/lib/requirementInput';
+import {
+  cleanRequirementText,
+  defaultCleanRules,
+  initialRequirementInputState,
+  loadDraftFromStorage,
+  saveDraftToStorage,
+} from '@/lib/requirementInput';
+
+const parseStepDelayMs = 650;
+const simulatedDocumentContent = `1. 项目概述
+本需求来自已上传需求文档，描述电商平台会员中心能力升级。
+
+2. 功能需求
+2.1 会员注册
+- 用户可通过手机号、邮箱进行注册。
+- 注册时需填写验证码，验证码有效期为 5 分钟。
+用户点击注册后，
+系统需要校验验证码与账号唯一性。
+
+2.2 登录与登出
+- 支持账号密码登录。
+- 支持短信验证码登录。
+- 用户可主动退出登录。`;
+
+function buildInitialState(): RequirementInputState {
+  const draft = loadDraftFromStorage();
+
+  if (!draft) {
+    return initialRequirementInputState;
+  }
+
+  return {
+    ...initialRequirementInputState,
+    ...draft,
+    uploadedFiles: initialRequirementInputState.uploadedFiles,
+    rawContent: '',
+    cleanedContent: '',
+    parseStep: -1,
+    parseStatus: 'idle',
+  };
+}
+
+export default function RequirementInputParsePage(): JSX.Element {
+  const [state, setState] = useState<RequirementInputState>(buildInitialState);
+  const timersRef = useRef<number[]>([]);
+
+  const canStartParse = useMemo(
+    () => state.uploadedFiles.length > 0 || state.requirementText.trim().length > 0,
+    [state.requirementText, state.uploadedFiles.length]
+  );
+
+  const clearTimers = useCallback((): void => {
+    timersRef.current.forEach((timer) => window.clearTimeout(timer));
+    timersRef.current = [];
+  }, []);
+
+  useEffect(() => clearTimers, [clearTimers]);
+
+  const updateState = useCallback((partialState: Partial<RequirementInputState>): void => {
+    setState((current) => ({ ...current, ...partialState }));
+  }, []);
+
+  const handleFilesAdd = useCallback((files: UploadedFileItem[]): void => {
+    setState((current) => ({ ...current, uploadedFiles: [...files, ...current.uploadedFiles] }));
+    toast.success(`已添加 ${files.length} 个文件，等待解析`);
+  }, []);
+
+  const handleDeleteFile = useCallback((id: string): void => {
+    setState((current) => ({ ...current, uploadedFiles: current.uploadedFiles.filter((file) => file.id !== id) }));
+  }, []);
+
+  const handlePreviewFile = useCallback((): void => {
+    toast.info('文件预览功能暂未接入，后续支持在线预览。');
+  }, []);
+
+  const handleResetUpload = useCallback((): void => {
+    clearTimers();
+    setState((current) => ({
+      ...current,
+      uploadedFiles: [],
+      rawContent: '',
+      cleanedContent: '',
+      parseStep: -1,
+      parseStatus: 'idle',
+    }));
+    toast.success('已清空上传文件并重置解析进度');
+  }, [clearTimers]);
+
+  const handleSaveDraft = useCallback((): void => {
+    try {
+      saveDraftToStorage({
+        projectName: state.projectName,
+        requirementName: state.requirementName,
+        requirementType: state.requirementType,
+        generateTarget: state.generateTarget,
+        inputMode: state.inputMode,
+        requirementText: state.requirementText,
+        cleanRules: state.cleanRules,
+      });
+      toast.success('草稿已保存');
+    } catch {
+      toast.error('草稿保存失败，请稍后重试');
+    }
+  }, [state.cleanRules, state.generateTarget, state.inputMode, state.projectName, state.requirementName, state.requirementText, state.requirementType]);
+
+  const handleStartParse = useCallback((): void => {
+    if (!canStartParse) {
+      toast.error('请先上传需求文档或粘贴需求文本。');
+      return;
+    }
+
+    clearTimers();
+    const rawContent = state.requirementText.trim().length > 0 ? state.requirementText : simulatedDocumentContent;
+    setState((current) => ({
+      ...current,
+      rawContent,
+      cleanedContent: '',
+      parseStep: 0,
+      parseStatus: 'parsing',
+      uploadedFiles: current.uploadedFiles.map((file) => ({
+        ...file,
+        status: file.status === '上传失败' ? file.status : '上传成功',
+      })),
+    }));
+
+    [1, 2, 3].forEach((step) => {
+      const timer = window.setTimeout(() => {
+        setState((current) => ({ ...current, parseStep: step }));
+      }, parseStepDelayMs * step);
+      timersRef.current.push(timer);
+    });
+
+    const finishTimer = window.setTimeout(() => {
+      setState((current) => ({
+        ...current,
+        parseStep: 3,
+        parseStatus: 'success',
+        rawContent,
+        cleanedContent: cleanRequirementText(rawContent, current.cleanRules),
+      }));
+      toast.success('需求内容解析与清洗完成');
+    }, parseStepDelayMs * 4);
+    timersRef.current.push(finishTimer);
+  }, [canStartParse, clearTimers, state.requirementText]);
+
+  return (
+    <div className="min-h-full bg-slate-50 px-6 py-6 text-slate-900 lg:px-8">
+      <div className="mx-auto flex max-w-[1500px] flex-col gap-5">
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div>
+            <div className="mb-2 text-sm font-medium text-slate-500">页面 2 / 6 · 需求输入与解析</div>
+            <h1 className="text-3xl font-bold tracking-tight text-slate-950">需求输入与解析</h1>
+            <p className="mt-2 text-sm text-slate-500">上传或粘贴需求文档，智能解析并清洗内容，生成结构化需求信息。</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="button" variant="outline" className="gap-2 border-slate-200 bg-white" onClick={handleResetUpload}>
+              <RefreshCw className="h-4 w-4" />
+              重新上传
+            </Button>
+            <Button type="button" variant="outline" className="gap-2 border-slate-200 bg-white" onClick={handleSaveDraft}>
+              <Save className="h-4 w-4" />
+              保存草稿
+            </Button>
+            <Button type="button" className="gap-2 bg-blue-600 shadow-sm shadow-blue-200 hover:bg-blue-700" onClick={handleStartParse} disabled={!canStartParse || state.parseStatus === 'parsing'}>
+              <Play className="h-4 w-4" />
+              开始解析
+            </Button>
+          </div>
+        </header>
+
+        <section className="grid gap-5 xl:grid-cols-[minmax(0,0.95fr)_minmax(560px,1.05fr)]">
+          <div className="space-y-5">
+            <RequirementUploadPanel
+              inputMode={state.inputMode}
+              onInputModeChange={(inputMode: RequirementInputMode) => updateState({ inputMode })}
+              onFilesAdd={handleFilesAdd}
+            />
+            <RequirementTextEditor
+              value={state.requirementText}
+              onChange={(requirementText: string) => updateState({ requirementText })}
+            />
+          </div>
+
+          <div className="space-y-5">
+            <UploadedFileList files={state.uploadedFiles} onPreview={handlePreviewFile} onDelete={handleDeleteFile} />
+            <RequirementConfigForm
+              projectName={state.projectName}
+              requirementName={state.requirementName}
+              requirementType={state.requirementType}
+              generateTarget={state.generateTarget}
+              onProjectNameChange={(projectName: string) => updateState({ projectName })}
+              onRequirementNameChange={(requirementName: string) => updateState({ requirementName })}
+              onRequirementTypeChange={(requirementType: RequirementType) => updateState({ requirementType })}
+              onGenerateTargetChange={(generateTarget: GenerateTarget) => updateState({ generateTarget })}
+            />
+            <CleanRulesPanel
+              rules={state.cleanRules}
+              onChange={(cleanRules: CleanRules) => updateState({ cleanRules })}
+              onReset={() => updateState({ cleanRules: defaultCleanRules })}
+            />
+            <ParseProgressSteps parseStep={state.parseStep} parseStatus={state.parseStatus} />
+          </div>
+        </section>
+
+        <RequirementContentCompare rawContent={state.rawContent} cleanedContent={state.cleanedContent} />
+      </div>
+    </div>
+  );
+}

--- a/src/pages/cases/components/CleanRulesPanel.tsx
+++ b/src/pages/cases/components/CleanRulesPanel.tsx
@@ -1,0 +1,50 @@
+import { Info } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import type { CleanRules } from '@/lib/requirementInput';
+
+interface CleanRulesPanelProps {
+  rules: CleanRules;
+  onChange: (rules: CleanRules) => void;
+  onReset: () => void;
+}
+
+const ruleOptions: Array<{ key: keyof CleanRules; label: string }> = [
+  { key: 'removeEmptyLines', label: '删除空行' },
+  { key: 'removeExtraSpaces', label: '删除多余空格' },
+  { key: 'removeGarbledChars', label: '删除乱码字符' },
+  { key: 'keepHeadingLevel', label: '保留标题层级' },
+  { key: 'keepTableContent', label: '保留表格内容' },
+  { key: 'mergeAbnormalLineBreaks', label: '合并异常换行' },
+];
+
+export default function CleanRulesPanel({ rules, onChange, onReset }: CleanRulesPanelProps): JSX.Element {
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm shadow-slate-200/60">
+      <CardHeader className="flex-row items-center justify-between px-5 py-4">
+        <CardTitle className="flex items-center gap-2 text-base font-bold text-slate-950">
+          清洗规则
+          <Info className="h-4 w-4 text-slate-400" />
+        </CardTitle>
+        <Button type="button" variant="link" className="h-auto px-0 py-0 text-blue-600" onClick={onReset}>
+          重置为默认
+        </Button>
+      </CardHeader>
+      <CardContent className="px-5 pb-5">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {ruleOptions.map((option) => (
+            <label key={option.key} className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm text-slate-700 hover:bg-slate-50">
+              <Checkbox
+                checked={rules[option.key]}
+                onCheckedChange={(checked) => onChange({ ...rules, [option.key]: checked === true })}
+                className="rounded border-blue-500 data-[state=checked]:bg-blue-600"
+              />
+              {option.label}
+            </label>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/cases/components/ParseProgressSteps.tsx
+++ b/src/pages/cases/components/ParseProgressSteps.tsx
@@ -1,0 +1,60 @@
+import { CheckCircle2, Circle, UploadCloud, FileSearch, Loader2, Sparkles } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+import type { ParseStatus } from '@/lib/requirementInput';
+
+interface ParseProgressStepsProps {
+  parseStep: number;
+  parseStatus: ParseStatus;
+}
+
+const steps = [
+  { label: '上传完成', icon: UploadCloud },
+  { label: '文档解析', icon: FileSearch },
+  { label: '内容清洗', icon: Sparkles },
+  { label: '结构化完成', icon: CheckCircle2 },
+] as const;
+
+export default function ParseProgressSteps({ parseStep, parseStatus }: ParseProgressStepsProps): JSX.Element {
+  const progressValue = parseStatus === 'idle' ? 0 : Math.min(((parseStep + 1) / steps.length) * 100, 100);
+
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm shadow-slate-200/60">
+      <CardHeader className="px-5 py-4">
+        <CardTitle className="text-base font-bold text-slate-950">解析进度</CardTitle>
+      </CardHeader>
+      <CardContent className="px-5 pb-5">
+        <Progress value={progressValue} className="mb-5 h-2 bg-slate-100" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-4">
+          {steps.map((step, index) => {
+            const Icon = step.icon;
+            const isFinished = parseStatus === 'success' ? index <= parseStep : index < parseStep;
+            const isLoading = parseStatus === 'parsing' && index === parseStep;
+            const isWaiting = !isFinished && !isLoading;
+
+            return (
+              <div key={step.label} className="relative flex items-center gap-3 sm:flex-col sm:items-start">
+                <div className={`flex h-9 w-9 items-center justify-center rounded-full text-sm font-bold ${
+                  isFinished
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : isLoading
+                      ? 'bg-blue-600 text-white shadow-md shadow-blue-200'
+                      : 'bg-slate-100 text-slate-400'
+                }`}
+                >
+                  {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : isWaiting ? <Circle className="h-4 w-4" /> : <Icon className="h-4 w-4" />}
+                </div>
+                <div>
+                  <div className={`text-sm font-semibold ${isWaiting ? 'text-slate-400' : 'text-slate-800'}`}>{step.label}</div>
+                  <div className="mt-1 text-xs text-slate-400">
+                    {isFinished ? '已完成' : isLoading ? '处理中' : '等待中'}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/cases/components/RequirementConfigForm.tsx
+++ b/src/pages/cases/components/RequirementConfigForm.tsx
@@ -1,0 +1,74 @@
+import { Input } from '@/components/ui/input';
+import type { GenerateTarget, RequirementType } from '@/lib/requirementInput';
+import { generateTargetOptions, requirementTypeOptions } from '@/lib/requirementInput';
+
+interface RequirementConfigFormProps {
+  projectName: string;
+  requirementName: string;
+  requirementType: RequirementType;
+  generateTarget: GenerateTarget;
+  onProjectNameChange: (value: string) => void;
+  onRequirementNameChange: (value: string) => void;
+  onRequirementTypeChange: (value: RequirementType) => void;
+  onGenerateTargetChange: (value: GenerateTarget) => void;
+}
+
+const selectClassName = 'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-slate-700 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50';
+
+export default function RequirementConfigForm({
+  projectName,
+  requirementName,
+  requirementType,
+  generateTarget,
+  onProjectNameChange,
+  onRequirementNameChange,
+  onRequirementTypeChange,
+  onGenerateTargetChange,
+}: RequirementConfigFormProps): JSX.Element {
+  return (
+    <div className="grid grid-cols-1 gap-4 rounded-xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-200/60 md:grid-cols-2 xl:grid-cols-4">
+      <label className="space-y-2">
+        <span className="text-sm font-semibold text-slate-800">项目名称 <span className="text-red-500">*</span></span>
+        <Input
+          value={projectName}
+          onChange={(event) => onProjectNameChange(event.target.value)}
+          placeholder="请输入项目名称"
+          className="border-slate-200 focus-visible:ring-blue-500"
+        />
+      </label>
+      <label className="space-y-2">
+        <span className="text-sm font-semibold text-slate-800">需求名称 <span className="text-red-500">*</span></span>
+        <Input
+          value={requirementName}
+          onChange={(event) => onRequirementNameChange(event.target.value)}
+          placeholder="请输入需求名称"
+          className="border-slate-200 focus-visible:ring-blue-500"
+        />
+      </label>
+      <label className="space-y-2">
+        <span className="text-sm font-semibold text-slate-800">需求类型</span>
+        <select
+          value={requirementType}
+          onChange={(event) => onRequirementTypeChange(event.target.value as RequirementType)}
+          className={selectClassName}
+        >
+          {requirementTypeOptions.map((option) => (
+            <option key={option} value={option}>{option}</option>
+          ))}
+        </select>
+      </label>
+      <label className="space-y-2">
+        <span className="text-sm font-semibold text-slate-800">生成目标 <span className="text-red-500">*</span></span>
+        <select
+          value={generateTarget}
+          onChange={(event) => onGenerateTargetChange(event.target.value as GenerateTarget)}
+          className={selectClassName}
+        >
+          {generateTargetOptions.map((option) => (
+            <option key={option} value={option}>{option}</option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/src/pages/cases/components/RequirementContentCompare.tsx
+++ b/src/pages/cases/components/RequirementContentCompare.tsx
@@ -1,0 +1,54 @@
+import { ArrowRight, CheckCircle2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface RequirementContentCompareProps {
+  rawContent: string;
+  cleanedContent: string;
+}
+
+function PreviewPanel({ content, emptyText }: { content: string; emptyText: string }): JSX.Element {
+  if (!content) {
+    return (
+      <div className="flex h-72 items-center justify-center rounded-xl border border-dashed border-slate-200 bg-slate-50/60 px-6 text-center text-sm text-slate-400">
+        {emptyText}
+      </div>
+    );
+  }
+
+  return (
+    <pre className="h-72 overflow-auto whitespace-pre-wrap rounded-xl border border-slate-200 bg-slate-50/80 p-4 font-mono text-sm leading-6 text-slate-800">
+      {content}
+    </pre>
+  );
+}
+
+export default function RequirementContentCompare({ rawContent, cleanedContent }: RequirementContentCompareProps): JSX.Element {
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm shadow-slate-200/60">
+      <CardContent className="grid gap-4 p-5 lg:grid-cols-[1fr_auto_1fr]">
+        <div>
+          <CardHeader className="px-0 pb-3 pt-0">
+            <CardTitle className="text-base font-bold text-slate-950">原始内容</CardTitle>
+          </CardHeader>
+          <PreviewPanel content={rawContent} emptyText="暂无原始内容，请上传文档或粘贴需求文本。" />
+        </div>
+        <div className="hidden items-center justify-center px-1 text-slate-300 lg:flex">
+          <ArrowRight className="h-5 w-5" />
+        </div>
+        <div>
+          <CardHeader className="flex-row items-center justify-between px-0 pb-3 pt-0">
+            <CardTitle className="text-base font-bold text-slate-950">清洗后内容</CardTitle>
+            {cleanedContent && (
+              <Badge variant="success" className="gap-1 border-0">
+                <CheckCircle2 className="h-3.5 w-3.5" />
+                清洗完成
+              </Badge>
+            )}
+          </CardHeader>
+          <PreviewPanel content={cleanedContent} emptyText="暂无清洗结果，请点击开始解析。" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/cases/components/RequirementTextEditor.tsx
+++ b/src/pages/cases/components/RequirementTextEditor.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+
+interface RequirementTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  maxLength?: number;
+}
+
+export default function RequirementTextEditor({
+  value,
+  onChange,
+  maxLength = 100000,
+}: RequirementTextEditorProps): JSX.Element {
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm shadow-slate-200/60">
+      <CardHeader className="px-5 py-4">
+        <CardTitle className="text-base font-bold text-slate-950">
+          需求文本
+          <span className="ml-2 text-xs font-medium text-slate-400">（支持手动编辑）</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="px-5 pb-5">
+        <Textarea
+          value={value}
+          maxLength={maxLength}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="请输入或粘贴需求内容，例如业务需求、接口说明、产品规则、异常流程等。"
+          className="min-h-[260px] resize-none rounded-xl border-slate-200 bg-slate-50/50 font-mono text-sm leading-6 text-slate-800 focus-visible:ring-blue-500"
+        />
+        <div className="mt-2 text-right text-xs text-slate-400">
+          {value.length.toLocaleString('zh-CN')} / {maxLength.toLocaleString('zh-CN')}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/cases/components/RequirementUploadPanel.tsx
+++ b/src/pages/cases/components/RequirementUploadPanel.tsx
@@ -1,0 +1,153 @@
+import { ChangeEvent, DragEvent, useRef, useState } from 'react';
+import { FileSpreadsheet, FileText, FileType2, UploadCloud } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import type { RequirementInputMode, UploadedFileItem } from '@/lib/requirementInput';
+import { formatFileSize, getFileType } from '@/lib/requirementInput';
+
+interface RequirementUploadPanelProps {
+  inputMode: RequirementInputMode;
+  onInputModeChange: (mode: RequirementInputMode) => void;
+  onFilesAdd: (files: UploadedFileItem[]) => void;
+}
+
+const acceptedFileExtensions = '.doc,.docx,.pdf,.md,.txt,.xls,.xlsx';
+
+const formatTags = [
+  { label: 'Word', suffix: '.docx', icon: FileText, className: 'bg-blue-50 text-blue-700 border-blue-100' },
+  { label: 'PDF', suffix: '.pdf', icon: FileType2, className: 'bg-red-50 text-red-700 border-red-100' },
+  { label: 'Markdown', suffix: '.md', icon: FileText, className: 'bg-slate-50 text-slate-700 border-slate-200' },
+  { label: 'Excel', suffix: '.xlsx', icon: FileSpreadsheet, className: 'bg-emerald-50 text-emerald-700 border-emerald-100' },
+] as const;
+
+export default function RequirementUploadPanel({
+  inputMode,
+  onInputModeChange,
+  onFilesAdd,
+}: RequirementUploadPanelProps): JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const createFileItems = (files: FileList): UploadedFileItem[] => Array.from(files).map((file) => ({
+    id: `${file.name}-${file.size}-${file.lastModified}`,
+    name: file.name,
+    size: formatFileSize(file.size),
+    status: file.size > 50 * 1024 * 1024 ? '上传失败' : '等待解析',
+    type: getFileType(file.name),
+  }));
+
+  const handleFiles = (files: FileList | null): void => {
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    onFilesAdd(createFileItems(files));
+  };
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    handleFiles(event.target.files);
+    event.target.value = '';
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>): void => {
+    event.preventDefault();
+    setIsDragging(false);
+    handleFiles(event.dataTransfer.files);
+  };
+
+  return (
+    <Card className="overflow-hidden border-slate-200 bg-white shadow-sm shadow-slate-200/50">
+      <div className="flex border-b border-slate-100 bg-white px-5 pt-3">
+        <button
+          type="button"
+          onClick={() => onInputModeChange('upload')}
+          className={`border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+            inputMode === 'upload'
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-slate-500 hover:text-slate-900'
+          }`}
+        >
+          上传文档
+        </button>
+        <button
+          type="button"
+          onClick={() => onInputModeChange('text')}
+          className={`border-b-2 px-4 py-3 text-sm font-semibold transition-colors ${
+            inputMode === 'text'
+              ? 'border-blue-600 text-blue-600'
+              : 'border-transparent text-slate-500 hover:text-slate-900'
+          }`}
+        >
+          粘贴文本
+        </button>
+      </div>
+
+      <CardContent className="p-5">
+        {inputMode === 'text' ? (
+          <div className="flex min-h-[220px] flex-col items-center justify-center rounded-xl border border-dashed border-cyan-200 bg-cyan-50/50 px-6 text-center">
+            <FileText className="mb-3 h-9 w-9 text-cyan-600" />
+            <p className="text-base font-semibold text-slate-900">已切换为粘贴文本模式</p>
+            <p className="mt-2 max-w-md text-sm text-slate-500">请在下方“需求文本”区域粘贴或编辑需求内容，系统会基于文本执行模拟解析与清洗。</p>
+          </div>
+        ) : (
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={() => inputRef.current?.click()}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              inputRef.current?.click();
+            }
+          }}
+          onDragEnter={(event) => {
+            event.preventDefault();
+            setIsDragging(true);
+          }}
+          onDragOver={(event) => event.preventDefault()}
+          onDragLeave={() => setIsDragging(false)}
+          onDrop={handleDrop}
+          className={`flex min-h-[220px] cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed p-6 text-center transition-all ${
+            isDragging
+              ? 'border-blue-500 bg-blue-50 shadow-inner'
+              : 'border-slate-300 bg-gradient-to-b from-slate-50/70 to-white hover:border-blue-300 hover:bg-blue-50/50'
+          }`}
+        >
+          <input
+            ref={inputRef}
+            className="hidden"
+            type="file"
+            accept={acceptedFileExtensions}
+            multiple
+            onChange={handleInputChange}
+          />
+          <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-blue-50 text-blue-600">
+            <UploadCloud className="h-8 w-8" />
+          </div>
+          <p className="text-base font-semibold text-slate-900">
+            将文档拖拽到此处，或
+            <Button type="button" variant="link" className="h-auto px-1 py-0 text-blue-600">
+              点击上传
+            </Button>
+          </p>
+          <p className="mt-2 text-sm text-slate-500">支持 Word、PDF、Markdown、Excel 格式，单个文件不超过 50MB</p>
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            {formatTags.map((tag) => {
+              const Icon = tag.icon;
+              return (
+                <span key={tag.label} className={`inline-flex items-center gap-2 rounded-lg border px-3 py-2 ${tag.className}`}>
+                  <Icon className="h-4 w-4" />
+                  <span className="text-left text-xs font-semibold leading-tight">
+                    {tag.label}
+                    <br />
+                    <span className="font-normal opacity-75">{tag.suffix}</span>
+                  </span>
+                </span>
+              );
+            })}
+          </div>
+        </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/cases/components/UploadedFileList.tsx
+++ b/src/pages/cases/components/UploadedFileList.tsx
@@ -1,0 +1,84 @@
+import { Eye, FileSpreadsheet, FileText, FileType2, Trash2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { UploadedFileItem, UploadedFileType } from '@/lib/requirementInput';
+
+interface UploadedFileListProps {
+  files: UploadedFileItem[];
+  onPreview: (file: UploadedFileItem) => void;
+  onDelete: (id: string) => void;
+}
+
+function getFileIcon(type: UploadedFileType): JSX.Element {
+  if (type === 'pdf') return <FileType2 className="h-4 w-4 text-red-600" />;
+  if (type === 'excel') return <FileSpreadsheet className="h-4 w-4 text-emerald-600" />;
+  return <FileText className="h-4 w-4 text-blue-600" />;
+}
+
+function getStatusBadge(status: UploadedFileItem['status']): JSX.Element {
+  if (status === '上传成功') {
+    return <Badge variant="success" className="border-0">上传成功</Badge>;
+  }
+
+  if (status === '上传失败') {
+    return <Badge variant="destructive" className="border-0">上传失败</Badge>;
+  }
+
+  return <Badge variant="warning" className="border-0">等待解析</Badge>;
+}
+
+export default function UploadedFileList({ files, onPreview, onDelete }: UploadedFileListProps): JSX.Element {
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm shadow-slate-200/60">
+      <CardHeader className="px-5 py-4">
+        <CardTitle className="text-base font-bold text-slate-950">已上传文件（{files.length}）</CardTitle>
+      </CardHeader>
+      <CardContent className="px-5 pb-5">
+        <div className="overflow-hidden rounded-xl border border-slate-200">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-slate-50 text-xs font-semibold text-slate-500">
+              <tr>
+                <th className="px-4 py-3">文件名</th>
+                <th className="w-24 px-4 py-3">大小</th>
+                <th className="w-28 px-4 py-3">状态</th>
+                <th className="w-24 px-4 py-3 text-center">操作</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {files.map((file) => (
+                <tr key={file.id} className="hover:bg-slate-50/80">
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2 font-medium text-slate-800">
+                      {getFileIcon(file.type)}
+                      <span className="max-w-[260px] truncate" title={file.name}>{file.name}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-slate-600">{file.size}</td>
+                  <td className="px-4 py-3">{getStatusBadge(file.status)}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-center gap-2">
+                      <Button type="button" size="icon" variant="outline" className="h-8 w-8" onClick={() => onPreview(file)} aria-label={`预览 ${file.name}`}>
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                      <Button type="button" size="icon" variant="outline" className="h-8 w-8 text-slate-500 hover:text-red-600" onClick={() => onDelete(file.id)} aria-label={`删除 ${file.name}`}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {files.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-10 text-center text-sm text-slate-500">
+                    暂无上传文件，请在左侧上传需求文档。
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
### Motivation

- Provide a dedicated page to upload or paste requirement documents, intelligently parse and clean the content, and generate structured requirement data for downstream test/case generation.
- Centralize parsing and cleaning logic for requirement text so it can be reused across the UI and persisted as a draft.

### Description

- Add a parsing utility `src/lib/requirementInput.ts` that implements `cleanRequirementText`, file helpers `getFileType` and `formatFileSize`, default clean rules, draft storage helpers `loadDraftFromStorage`/`saveDraftToStorage`, and related types and mocks.
- Implement the new page `src/pages/cases/RequirementInputParsePage.tsx` with simulated parsing flow, timers, toast notifications, and state persisted via the draft helpers.
- Add multiple UI components under `src/pages/cases/components/` to support the page: `RequirementUploadPanel`, `RequirementTextEditor`, `RequirementConfigForm`, `CleanRulesPanel`, `ParseProgressSteps`, `UploadedFileList`, and `RequirementContentCompare`.
- Wire the page into the app by importing and registering the route in `src/App.tsx` and adding a navigation entry with icon in `src/components/Sidebar.tsx`.

### Testing

- Added unit tests in `src/components/__tests__/RequirementInputUtils.test.tsx` that exercise `cleanRequirementText`, `getFileType`, and `formatFileSize` behaviors and edge cases.
- Ran the new Vitest unit test file with `vitest` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eaf03f2ec833282eeefb1a801b776)