### PR TITLE
Add Requirement Input & Parsing workspace (UI, utils, and tests)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import PerformanceCases from "./pages/cases/PerformanceCases";
 import AICases from "./pages/cases/AICases";
 import AICaseCreate from "./pages/cases/AICaseCreate";
 import AICaseHistory from "./pages/cases/AICaseHistory";
+import RequirementInputParsePage from "./pages/cases/RequirementInputParsePage";
 import Reports from "./pages/reports/Reports";
 import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
@@ -182,6 +183,13 @@ function Router() {
           <ProtectedRoute>
             <Layout>
               <AICaseHistory />
+            </Layout>
+          </ProtectedRoute>
+        </Route>
+        <Route path="/requirements/input-parse">
+          <ProtectedRoute>
+            <Layout>
+              <RequirementInputParsePage />
             </Layout>
           </ProtectedRoute>
         </Route>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Gauge,
   BrainCircuit,
   History,
+  ClipboardList,
   PanelLeftClose,
   PanelLeftOpen
 } from "lucide-react";
@@ -55,6 +56,7 @@ const navItems: NavItem[] = [
     label: "AI 工作台",
     children: [
       { label: "工作台首页", href: "/cases/ai-create", icon: <BrainCircuit className="h-4 w-4" /> },
+      { label: "需求输入与解析", href: "/requirements/input-parse", icon: <ClipboardList className="h-4 w-4" /> },
       { label: "全部记录", href: "/cases/ai-history", icon: <History className="h-4 w-4" /> },
     ],
   },

--- a/src/components/__tests__/RequirementInputUtils.test.tsx
+++ b/src/components/__tests__/RequirementInputUtils.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { cleanRequirementText } from "@/pages/cases/requirementInputUtils";
+
+describe("cleanRequirementText", () => {
+  it("删除空行", () => {
+    const result = cleanRequirementText("需求 A\n\n\n需求 B", { mergeBrokenLines: false });
+
+    expect(result).toBe("需求 A\n需求 B");
+  });
+
+  it("删除多余空格", () => {
+    const result = cleanRequirementText("  用户   可以\t创建　订单  ", { mergeBrokenLines: false });
+
+    expect(result).toBe("用户 可以 创建 订单");
+  });
+
+  it("删除不可见字符", () => {
+    const result = cleanRequirementText("登录\u200B后\uFEFF展示首页", { mergeBrokenLines: false });
+
+    expect(result).toBe("登录后展示首页");
+  });
+
+  it("合并异常换行", () => {
+    const result = cleanRequirementText("用户提交订单后\n系统需要校验库存\n并返回支付链接");
+
+    expect(result).toBe("用户提交订单后 系统需要校验库存 并返回支付链接");
+  });
+
+  it("保留 Markdown 表格", () => {
+    const markdownTable = "| 字段 | 说明 |\n| --- | --- |\n| name | 用户名称 |";
+    const result = cleanRequirementText(`会员资料字段\n${markdownTable}\n字段需要支持编辑`);
+
+    expect(result).toBe(`会员资料字段\n${markdownTable}\n字段需要支持编辑`);
+  });
+});

--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useState } from "react";
+import { ClipboardList, Play, Save, Sparkles } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import CleanRulesPanel from "@/pages/cases/components/CleanRulesPanel";
+import ParseProgressSteps from "@/pages/cases/components/ParseProgressSteps";
+import RequirementConfigForm, { RequirementConfig } from "@/pages/cases/components/RequirementConfigForm";
+import RequirementContentCompare from "@/pages/cases/components/RequirementContentCompare";
+import RequirementTextEditor from "@/pages/cases/components/RequirementTextEditor";
+import RequirementUploadPanel from "@/pages/cases/components/RequirementUploadPanel";
+import UploadedFileList, { UploadedRequirementFile } from "@/pages/cases/components/UploadedFileList";
+import {
+  cleanRequirementText,
+  defaultCleanRequirementOptions,
+  getFileType,
+  loadDraftFromStorage,
+  saveDraftToStorage,
+  CleanRequirementOptions,
+} from "@/pages/cases/requirementInputUtils";
+
+const textFileTypes = new Set(["markdown", "text", "excel"]);
+
+function readFileAsText(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => reject(new Error(`无法读取文件：${file.name}`));
+    reader.readAsText(file);
+  });
+}
+
+function RequirementInputParsePage() {
+  const draft = useMemo(() => loadDraftFromStorage(), []);
+  const [rawText, setRawText] = useState(draft?.rawText ?? "");
+  const [rules, setRules] = useState<CleanRequirementOptions>(defaultCleanRequirementOptions);
+  const [files, setFiles] = useState<UploadedRequirementFile[]>([]);
+  const [progress, setProgress] = useState(35);
+  const [config, setConfig] = useState<RequirementConfig>({
+    title: draft?.title ?? "",
+    productLine: draft?.productLine ?? "",
+    priority: draft?.priority ?? "P1",
+    enableAiSummary: draft?.enableAiSummary ?? true,
+    enableRiskScan: draft?.enableRiskScan ?? true,
+    enableCaseSuggestion: draft?.enableCaseSuggestion ?? true,
+  });
+
+  const cleanedText = useMemo(() => cleanRequirementText(rawText, rules), [rawText, rules]);
+  const wordCount = cleanedText.length;
+
+  useEffect(() => {
+    const nextProgress = Math.min(100, 35 + (files.length > 0 ? 15 : 0) + (rawText.trim() ? 25 : 0) + (cleanedText.trim() ? 25 : 0));
+    setProgress(nextProgress);
+  }, [cleanedText, files.length, rawText]);
+
+  const handleFilesSelected = (selectedFiles: File[]) => {
+    selectedFiles.forEach((file) => {
+      const fileType = getFileType(file.name);
+      const baseFile: UploadedRequirementFile = {
+        id: `${file.name}-${file.lastModified}-${file.size}`,
+        name: file.name,
+        size: file.size,
+        type: fileType,
+      };
+
+      setFiles((currentFiles) => [...currentFiles, baseFile]);
+
+      if (textFileTypes.has(fileType)) {
+        readFileAsText(file)
+          .then((content) => {
+            setFiles((currentFiles) => currentFiles.map((item) => (item.id === baseFile.id ? { ...item, extractedText: content } : item)));
+            setRawText((currentText) => [currentText, content].filter((item) => item.trim().length > 0).join("\n\n"));
+          })
+          .catch((error: unknown) => {
+            console.warn("读取需求附件失败", error);
+          });
+      }
+    });
+  };
+
+  const handleSaveDraft = () => {
+    saveDraftToStorage({
+      ...config,
+      rawText,
+      cleanedText,
+      updatedAt: new Date().toISOString(),
+    });
+  };
+
+  const handleStartParse = () => {
+    setProgress(100);
+    handleSaveDraft();
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50/80 p-6 dark:bg-slate-950">
+      <div className="mx-auto max-w-7xl space-y-6">
+        <div className="flex flex-col gap-4 rounded-2xl bg-gradient-to-r from-blue-600 to-indigo-600 p-6 text-white shadow-lg shadow-blue-500/20 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <Badge className="mb-3 bg-white/20 text-white hover:bg-white/20">AI 工作台</Badge>
+            <h1 className="flex items-center gap-3 text-2xl font-bold md:text-3xl">
+              <ClipboardList className="h-8 w-8" />
+              需求输入与解析
+            </h1>
+            <p className="mt-2 max-w-3xl text-sm text-blue-50">
+              汇总附件与原始需求文本，完成规则清洗、内容对比和解析配置，为 AI 用例生成提供高质量输入。
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            <Button className="bg-white text-blue-700 hover:bg-blue-50" type="button" onClick={handleSaveDraft}>
+              <Save className="mr-2 h-4 w-4" />
+              保存草稿
+            </Button>
+            <Button className="bg-slate-950 text-white hover:bg-slate-800" type="button" onClick={handleStartParse}>
+              <Play className="mr-2 h-4 w-4" />
+              开始解析
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[360px_1fr]">
+          <div className="space-y-6">
+            <RequirementUploadPanel onFilesSelected={handleFilesSelected} />
+            <UploadedFileList files={files} onRemove={(id) => setFiles((currentFiles) => currentFiles.filter((file) => file.id !== id))} />
+            <CleanRulesPanel rules={rules} onChange={setRules} />
+          </div>
+
+          <div className="space-y-6">
+            <RequirementConfigForm config={config} onChange={setConfig} />
+            <RequirementTextEditor value={rawText} onChange={setRawText} />
+            <ParseProgressSteps progress={progress} />
+            <Card className="border-blue-100 bg-blue-50/70 dark:border-blue-900 dark:bg-blue-950/20">
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
+                <div className="flex items-center gap-2 text-sm text-blue-900 dark:text-blue-100">
+                  <Sparkles className="h-4 w-4" />
+                  清洗后共 {wordCount} 个字符，可继续调整规则或直接启动解析。
+                </div>
+                <Badge variant={wordCount > 0 ? "success" : "warning"}>{wordCount > 0 ? "输入就绪" : "等待输入"}</Badge>
+              </CardContent>
+            </Card>
+            <RequirementContentCompare rawText={rawText} cleanedText={cleanedText} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RequirementInputParsePage;

--- a/src/pages/cases/components/CleanRulesPanel.tsx
+++ b/src/pages/cases/components/CleanRulesPanel.tsx
@@ -1,0 +1,44 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { CleanRequirementOptions } from "@/pages/cases/requirementInputUtils";
+
+interface CleanRulesPanelProps {
+  rules: CleanRequirementOptions;
+  onChange: (rules: CleanRequirementOptions) => void;
+}
+
+const ruleItems: Array<{ key: keyof CleanRequirementOptions; label: string; description: string }> = [
+  { key: "removeEmptyLines", label: "删除空行", description: "移除连续空白行，压缩需求结构。" },
+  { key: "trimExtraSpaces", label: "删除多余空格", description: "合并半角、全角空格与 Tab。" },
+  { key: "removeInvisibleChars", label: "删除不可见字符", description: "清除零宽字符和 BOM。" },
+  { key: "mergeBrokenLines", label: "合并异常换行", description: "修复复制粘贴导致的句内断行。" },
+  { key: "preserveMarkdownTables", label: "保留 Markdown 表格", description: "避免清洗过程破坏表格行。" },
+];
+
+function CleanRulesPanel({ rules, onChange }: CleanRulesPanelProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">清洗规则</CardTitle>
+        <CardDescription>按需开启文本规范化规则，清洗后可在右侧对比预览。</CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-3 md:grid-cols-2 xl:grid-cols-1">
+        {ruleItems.map((item) => (
+          <label key={item.key} className="flex items-start gap-3 rounded-lg border border-slate-200 p-3 transition hover:bg-slate-50 dark:border-slate-800 dark:hover:bg-slate-900">
+            <Checkbox
+              checked={rules[item.key]}
+              className="mt-1"
+              onCheckedChange={(checked) => onChange({ ...rules, [item.key]: checked === true })}
+            />
+            <span>
+              <span className="block text-sm font-medium text-slate-800 dark:text-slate-100">{item.label}</span>
+              <span className="mt-1 block text-xs text-slate-500 dark:text-slate-400">{item.description}</span>
+            </span>
+          </label>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default CleanRulesPanel;

--- a/src/pages/cases/components/ParseProgressSteps.tsx
+++ b/src/pages/cases/components/ParseProgressSteps.tsx
@@ -1,0 +1,38 @@
+import { CheckCircle2, CircleDot, Clock } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface ParseProgressStepsProps {
+  progress: number;
+}
+
+const steps = ["需求接入", "文本清洗", "结构化解析", "测试点生成"];
+
+function ParseProgressSteps({ progress }: ParseProgressStepsProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">解析进度</CardTitle>
+        <CardDescription>当前为前端交互预览，后续可接入真实异步解析任务。</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Progress value={progress} />
+        <div className="grid gap-3 md:grid-cols-4">
+          {steps.map((step, index) => {
+            const threshold = (index + 1) * 25;
+            const isDone = progress >= threshold;
+            const isActive = progress > index * 25 && progress < threshold;
+            return (
+              <div key={step} className="flex items-center gap-2 rounded-lg bg-slate-50 px-3 py-2 text-sm dark:bg-slate-900">
+                {isDone ? <CheckCircle2 className="h-4 w-4 text-green-500" /> : isActive ? <CircleDot className="h-4 w-4 text-blue-500" /> : <Clock className="h-4 w-4 text-slate-400" />}
+                <span className={isDone || isActive ? "font-medium text-slate-800 dark:text-slate-100" : "text-slate-500 dark:text-slate-400"}>{step}</span>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default ParseProgressSteps;

--- a/src/pages/cases/components/RequirementConfigForm.tsx
+++ b/src/pages/cases/components/RequirementConfigForm.tsx
@@ -1,0 +1,64 @@
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export interface RequirementConfig {
+  title: string;
+  productLine: string;
+  priority: string;
+  enableAiSummary: boolean;
+  enableRiskScan: boolean;
+  enableCaseSuggestion: boolean;
+}
+
+interface RequirementConfigFormProps {
+  config: RequirementConfig;
+  onChange: (config: RequirementConfig) => void;
+}
+
+function RequirementConfigForm({ config, onChange }: RequirementConfigFormProps) {
+  const updateConfig = <Key extends keyof RequirementConfig>(key: Key, value: RequirementConfig[Key]) => {
+    onChange({ ...config, [key]: value });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">解析配置</CardTitle>
+        <CardDescription>设置需求元信息和 AI 解析目标，便于后续生成测试点与用例。</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid gap-4 md:grid-cols-3">
+          <label className="space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+            需求标题
+            <Input value={config.title} placeholder="输入需求名称" onChange={(event) => updateConfig("title", event.target.value)} />
+          </label>
+          <label className="space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+            产品线
+            <Input value={config.productLine} placeholder="例如：交易平台" onChange={(event) => updateConfig("productLine", event.target.value)} />
+          </label>
+          <label className="space-y-2 text-sm font-medium text-slate-700 dark:text-slate-200">
+            优先级
+            <Input value={config.priority} placeholder="P0 / P1 / P2" onChange={(event) => updateConfig("priority", event.target.value)} />
+          </label>
+        </div>
+        <div className="grid gap-3 md:grid-cols-3">
+          <label className="flex items-center gap-2 rounded-lg border border-slate-200 p-3 text-sm dark:border-slate-800">
+            <Checkbox checked={config.enableAiSummary} onCheckedChange={(checked) => updateConfig("enableAiSummary", checked === true)} />
+            生成需求摘要
+          </label>
+          <label className="flex items-center gap-2 rounded-lg border border-slate-200 p-3 text-sm dark:border-slate-800">
+            <Checkbox checked={config.enableRiskScan} onCheckedChange={(checked) => updateConfig("enableRiskScan", checked === true)} />
+            扫描歧义与风险
+          </label>
+          <label className="flex items-center gap-2 rounded-lg border border-slate-200 p-3 text-sm dark:border-slate-800">
+            <Checkbox checked={config.enableCaseSuggestion} onCheckedChange={(checked) => updateConfig("enableCaseSuggestion", checked === true)} />
+            生成测试点建议
+          </label>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RequirementConfigForm;

--- a/src/pages/cases/components/RequirementContentCompare.tsx
+++ b/src/pages/cases/components/RequirementContentCompare.tsx
@@ -1,0 +1,39 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface RequirementContentCompareProps {
+  rawText: string;
+  cleanedText: string;
+}
+
+function RequirementContentCompare({ rawText, cleanedText }: RequirementContentCompareProps) {
+  const rawLineCount = rawText ? rawText.split("\n").length : 0;
+  const cleanLineCount = cleanedText ? cleanedText.split("\n").length : 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <CardTitle className="text-lg">内容清洗对比</CardTitle>
+            <CardDescription>左侧为原始输入，右侧为清洗后的解析候选内容。</CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Badge variant="outline">原始 {rawLineCount} 行</Badge>
+            <Badge variant="success">清洗 {cleanLineCount} 行</Badge>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="grid gap-4 lg:grid-cols-2">
+        <pre className="min-h-[260px] overflow-auto rounded-xl bg-slate-950 p-4 text-xs leading-6 text-slate-100">
+          {rawText || "暂无原始需求内容"}
+        </pre>
+        <pre className="min-h-[260px] overflow-auto rounded-xl bg-blue-950 p-4 text-xs leading-6 text-blue-50">
+          {cleanedText || "清洗后内容将在这里展示"}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RequirementContentCompare;

--- a/src/pages/cases/components/RequirementTextEditor.tsx
+++ b/src/pages/cases/components/RequirementTextEditor.tsx
@@ -1,0 +1,28 @@
+import { Textarea } from "@/components/ui/textarea";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface RequirementTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function RequirementTextEditor({ value, onChange }: RequirementTextEditorProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">原始需求文本</CardTitle>
+        <CardDescription>粘贴 PRD、用户故事、接口说明或测试验收标准，后续将基于清洗结果生成结构化内容。</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Textarea
+          className="min-h-[260px] resize-y font-mono text-sm leading-6"
+          placeholder="示例：\n作为运营人员，我希望可以批量导入优惠券规则...\n| 字段 | 说明 |\n| --- | --- |"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RequirementTextEditor;

--- a/src/pages/cases/components/RequirementUploadPanel.tsx
+++ b/src/pages/cases/components/RequirementUploadPanel.tsx
@@ -1,0 +1,45 @@
+import { UploadCloud } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface RequirementUploadPanelProps {
+  onFilesSelected: (files: File[]) => void;
+}
+
+function RequirementUploadPanel({ onFilesSelected }: RequirementUploadPanelProps) {
+  return (
+    <Card className="border-dashed border-blue-200 bg-blue-50/40 dark:border-blue-900/60 dark:bg-blue-950/20">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <UploadCloud className="h-5 w-5 text-blue-600" />
+          上传需求附件
+        </CardTitle>
+        <CardDescription>
+          支持 TXT、Markdown、PDF、Word、Excel 等需求材料，可与下方文本输入合并解析。
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <label className="flex cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed border-blue-300 bg-white/70 px-6 py-8 text-center transition hover:border-blue-500 hover:bg-white dark:border-blue-800 dark:bg-slate-900/60 dark:hover:border-blue-500">
+          <UploadCloud className="mb-3 h-10 w-10 text-blue-500" />
+          <span className="text-sm font-medium text-slate-700 dark:text-slate-200">点击选择或拖拽需求文件</span>
+          <span className="mt-1 text-xs text-slate-500 dark:text-slate-400">单次可选择多个文件，文本类文件会自动读取内容</span>
+          <input
+            className="sr-only"
+            multiple
+            type="file"
+            accept=".txt,.md,.markdown,.pdf,.doc,.docx,.xls,.xlsx,.csv"
+            onChange={(event) => {
+              onFilesSelected(Array.from(event.target.files ?? []));
+              event.target.value = "";
+            }}
+          />
+          <Button className="mt-4" type="button" variant="outline">
+            选择文件
+          </Button>
+        </label>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default RequirementUploadPanel;

--- a/src/pages/cases/components/UploadedFileList.tsx
+++ b/src/pages/cases/components/UploadedFileList.tsx
@@ -1,0 +1,56 @@
+import { FileText, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatFileSize, RequirementFileType } from "@/pages/cases/requirementInputUtils";
+
+export interface UploadedRequirementFile {
+  id: string;
+  name: string;
+  size: number;
+  type: RequirementFileType;
+  extractedText?: string;
+}
+
+interface UploadedFileListProps {
+  files: UploadedRequirementFile[];
+  onRemove: (id: string) => void;
+}
+
+function UploadedFileList({ files, onRemove }: UploadedFileListProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">已上传文件</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {files.length === 0 ? (
+          <div className="rounded-lg bg-slate-50 px-4 py-6 text-center text-sm text-slate-500 dark:bg-slate-900 dark:text-slate-400">
+            暂无附件，上传后会显示文件类型、大小和读取状态。
+          </div>
+        ) : (
+          files.map((file) => (
+            <div key={file.id} className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2 dark:border-slate-800 dark:bg-slate-950">
+              <div className="flex min-w-0 items-center gap-3">
+                <FileText className="h-5 w-5 shrink-0 text-blue-500" />
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{file.name}</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">{formatFileSize(file.size)}</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant="secondary">{file.type}</Badge>
+                {file.extractedText ? <Badge variant="success">已读取</Badge> : <Badge variant="outline">待解析</Badge>}
+                <Button aria-label={`移除 ${file.name}`} size="icon" type="button" variant="ghost" onClick={() => onRemove(file.id)}>
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default UploadedFileList;

--- a/src/pages/cases/requirementInputUtils.ts
+++ b/src/pages/cases/requirementInputUtils.ts
@@ -1,0 +1,187 @@
+export type RequirementFileType = "markdown" | "word" | "pdf" | "text" | "excel" | "unknown";
+
+export interface RequirementDraft {
+  title: string;
+  rawText: string;
+  cleanedText: string;
+  productLine: string;
+  priority: string;
+  enableAiSummary: boolean;
+  enableRiskScan: boolean;
+  enableCaseSuggestion: boolean;
+  updatedAt: string;
+}
+
+export interface CleanRequirementOptions {
+  removeEmptyLines: boolean;
+  trimExtraSpaces: boolean;
+  removeInvisibleChars: boolean;
+  mergeBrokenLines: boolean;
+  preserveMarkdownTables: boolean;
+}
+
+export const defaultCleanRequirementOptions: CleanRequirementOptions = {
+  removeEmptyLines: true,
+  trimExtraSpaces: true,
+  removeInvisibleChars: true,
+  mergeBrokenLines: true,
+  preserveMarkdownTables: true,
+};
+
+const storageKey = "automation-platform.requirement-input-draft";
+const markdownTableLinePattern = /^\s*\|.*\|\s*$/;
+const markdownTableDividerPattern = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+const sentenceEndingPattern = /[。！？.!?；;：:]$/;
+const listOrHeadingPattern = /^\s*(#{1,6}\s|[-*+]\s+|\d+[.)、]\s+|>\s+)/;
+
+function isMarkdownTableLine(line: string): boolean {
+  return markdownTableLinePattern.test(line) || markdownTableDividerPattern.test(line);
+}
+
+function normalizeVisibleSpacing(line: string): string {
+  const placeholder = "__REQ_INPUT_FULL_WIDTH_SPACE__";
+  return line
+    .replace(/　/g, placeholder)
+    .replace(/[\t ]+/g, " ")
+    .replace(new RegExp(placeholder, "g"), " ")
+    .trim();
+}
+
+function shouldMergeLine(previousLine: string, currentLine: string, preserveMarkdownTables: boolean): boolean {
+  if (!previousLine || !currentLine) {
+    return false;
+  }
+
+  if (preserveMarkdownTables && (isMarkdownTableLine(previousLine) || isMarkdownTableLine(currentLine))) {
+    return false;
+  }
+
+  if (listOrHeadingPattern.test(previousLine) || listOrHeadingPattern.test(currentLine)) {
+    return false;
+  }
+
+  if (sentenceEndingPattern.test(previousLine)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function cleanRequirementText(
+  input: string,
+  options: Partial<CleanRequirementOptions> = {}
+): string {
+  const mergedOptions: CleanRequirementOptions = {
+    ...defaultCleanRequirementOptions,
+    ...options,
+  };
+
+  let normalizedText = input.replace(/\r\n?/g, "\n");
+
+  if (mergedOptions.removeInvisibleChars) {
+    normalizedText = normalizedText.replace(/[\u200B-\u200D\uFEFF\u2060]/g, "");
+  }
+
+  let lines = normalizedText.split("\n").map((line) => {
+    if (mergedOptions.preserveMarkdownTables && isMarkdownTableLine(line)) {
+      return line.trim();
+    }
+
+    if (mergedOptions.trimExtraSpaces) {
+      return normalizeVisibleSpacing(line);
+    }
+
+    return line.trim();
+  });
+
+  if (mergedOptions.removeEmptyLines) {
+    lines = lines.filter((line) => line.length > 0);
+  }
+
+  if (!mergedOptions.mergeBrokenLines) {
+    return lines.join("\n").trim();
+  }
+
+  const mergedLines: string[] = [];
+
+  lines.forEach((line) => {
+    const previousLine = mergedLines[mergedLines.length - 1];
+
+    if (shouldMergeLine(previousLine, line, mergedOptions.preserveMarkdownTables)) {
+      mergedLines[mergedLines.length - 1] = `${previousLine}${line.match(/^[,，.。!?！？]/) ? "" : " "}${line}`;
+      return;
+    }
+
+    mergedLines.push(line);
+  });
+
+  return mergedLines.join("\n").trim();
+}
+
+export function getFileType(fileName: string): RequirementFileType {
+  const extension = fileName.split(".").pop()?.toLowerCase() ?? "";
+
+  if (["md", "markdown"].includes(extension)) {
+    return "markdown";
+  }
+
+  if (["doc", "docx"].includes(extension)) {
+    return "word";
+  }
+
+  if (extension === "pdf") {
+    return "pdf";
+  }
+
+  if (["txt", "text"].includes(extension)) {
+    return "text";
+  }
+
+  if (["xls", "xlsx", "csv"].includes(extension)) {
+    return "excel";
+  }
+
+  return "unknown";
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes <= 0) {
+    return "0 B";
+  }
+
+  const units = ["B", "KB", "MB", "GB"];
+  const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** unitIndex;
+
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+export function loadDraftFromStorage(): RequirementDraft | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    const rawDraft = window.localStorage.getItem(storageKey);
+    if (!rawDraft) {
+      return null;
+    }
+
+    return JSON.parse(rawDraft) as RequirementDraft;
+  } catch (error) {
+    console.warn("Failed to load requirement draft", error);
+    return null;
+  }
+}
+
+export function saveDraftToStorage(draft: RequirementDraft): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(draft));
+  } catch (error) {
+    console.warn("Failed to save requirement draft", error);
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide an AI workspace page to collect requirement attachments and raw text, apply cleaning rules, preview cleaned output, and prepare inputs for AI-based parsing and test-case generation.
- Reuse existing `ui` components and existing `ProtectedRoute`/`Layout` patterns for consistent UX and access control.
- Centralize text/file helpers and persist drafts so parsing workflows are repeatable and testable.

### Description

- Add a new protected page `RequirementInputParsePage` under `src/pages/cases/` and wire it into routing in `src/App.tsx` at the path `/requirements/input-parse`.
- Add an AI workspace sidebar item `需求输入与解析` with the `ClipboardList` icon in `src/components/Sidebar.tsx` to surface the new page.
- Split the page into focused components under `src/pages/cases/components/` (`RequirementUploadPanel`, `UploadedFileList`, `RequirementTextEditor`, `RequirementConfigForm`, `CleanRulesPanel`, `ParseProgressSteps`, `RequirementContentCompare`) and reuse `src/components/ui/*` building blocks.
- Introduce `src/pages/cases/requirementInputUtils.ts` implementing `cleanRequirementText`, `getFileType`, `formatFileSize`, `loadDraftFromStorage`, and `saveDraftToStorage` with configurable cleaning options.
- Add unit tests for `cleanRequirementText` at `src/components/__tests__/RequirementInputUtils.test.tsx` covering empty-line removal, extra-space trimming, invisible character removal, broken-line merging, and preserving Markdown tables.

### Testing

- Ran unit tests with `npx vitest run` for the new test file and the test suite passed (`1 test file, 5 tests — all passed`).
- Ran TypeScript type check with `npx tsc --noEmit -p tsconfig.json` which completed successfully.
- Executed a production build with `npm run build` which completed successfully without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ec50e776883328734d94090b03639)