### PR TITLE
Add risk-level filter to RequirementAnalysis and make sidebar path matching prefix-aware

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -75,9 +75,13 @@ const navItems: NavItem[] = [
 // ----------------------------------------------------------------
 // Utility: check if a nav item is active
 // ----------------------------------------------------------------
+function isPathActive(location: string, href: string): boolean {
+  return location === href || location.startsWith(`${href}/`);
+}
+
 function useNavActive(item: NavItem, location: string) {
-  const isActive = item.href ? location === item.href : false;
-  const isChildActive = item.children?.some((c) => location === c.href) ?? false;
+  const isActive = item.href ? isPathActive(location, item.href) : false;
+  const isChildActive = item.children?.some((child) => isPathActive(location, child.href)) ?? false;
   return { isActive: isActive || isChildActive, isChildActive };
 }
 
@@ -143,7 +147,7 @@ function MiniDrawer({ item, anchorRect, onClose, location, onNavigate }: MiniDra
       {item.children ? (
         <div className="px-2">
           {item.children.map((child) => {
-            const isActive = location === child.href;
+            const isActive = isPathActive(location, child.href);
             return (
               <button
                 key={child.href}
@@ -178,13 +182,13 @@ function MiniDrawer({ item, anchorRect, onClose, location, onNavigate }: MiniDra
             }}
             className={`
               w-full flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-sm transition-all duration-150
-              ${item.href && location === item.href
+              ${item.href && isPathActive(location, item.href)
                 ? "bg-primary text-white shadow-sm shadow-primary/25"
                 : "text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800"
               }
             `}
           >
-            <span className={item.href && location === item.href ? "text-white/80" : "text-slate-400 dark:text-slate-500"}>
+            <span className={item.href && isPathActive(location, item.href) ? "text-white/80" : "text-slate-400 dark:text-slate-500"}>
               {item.icon}
             </span>
             <span>前往 {item.label}</span>
@@ -317,7 +321,7 @@ function ExpandedNavItem({ item, location, onNavigate, defaultExpanded, badge }:
         >
           <div className="ml-3 pl-3 border-l-2 border-slate-100 dark:border-slate-800 space-y-0.5 py-1">
             {item.children?.map((child) => {
-              const childActive = location === child.href;
+              const childActive = isPathActive(location, child.href);
               return (
                 <button
                   type="button"

--- a/src/pages/RequirementAnalysis/index.module.css
+++ b/src/pages/RequirementAnalysis/index.module.css
@@ -217,7 +217,7 @@
 
 .filterBar {
   display: grid;
-  grid-template-columns: minmax(260px, 1fr) repeat(3, 160px);
+  grid-template-columns: minmax(260px, 1fr) repeat(4, 150px);
   gap: 12px;
   padding: 16px;
   margin: 20px 0;

--- a/src/pages/RequirementAnalysis/index.tsx
+++ b/src/pages/RequirementAnalysis/index.tsx
@@ -17,6 +17,7 @@ import type {
   RequirementRisk,
   TestPoint,
   TestPointFormValues,
+  RiskLevel,
   TestPointModalMode,
   TestPointPriority,
   TestPointStatus,
@@ -138,6 +139,7 @@ export default function RequirementAnalysis(): JSX.Element {
 
   const updatePriority = (priority: TestPointPriority | 'all') => setFilters((current) => ({ ...current, priority }));
   const updateStatus = (status: TestPointStatus | 'all') => setFilters((current) => ({ ...current, status }));
+  const updateRiskLevel = (riskLevel: RiskLevel | 'all') => setFilters((current) => ({ ...current, riskLevel }));
 
   return (
     <main className={styles.pageShell}>
@@ -179,6 +181,12 @@ export default function RequirementAnalysis(): JSX.Element {
           <option value="draft">草稿</option>
           <option value="generated">已生成</option>
           <option value="confirmed">已确认</option>
+        </select>
+        <select value={filters.riskLevel} onChange={(event) => updateRiskLevel(event.target.value as RiskLevel | 'all')}>
+          <option value="all">全部风险</option>
+          <option value="high">高风险</option>
+          <option value="medium">中风险</option>
+          <option value="low">低风险</option>
         </select>
       </section>
 


### PR DESCRIPTION
### Motivation
- Provide a risk-level selector in the Requirement Analysis UI to allow users to filter risk cards by severity. 
- Adjust the filter layout to accommodate the new selector while preserving existing enterprise card styling. 
- Ensure the sidebar highlights the AI Workbench menu when navigating to `/requirement-analysis` and nested routes. 

### Description
- Added a risk-level filter dropdown and handler in `src/pages/RequirementAnalysis/index.tsx` and wired it into the existing `visibleRisks` filter logic. 
- Expanded the filter bar layout by updating `src/pages/RequirementAnalysis/index.module.css` to make room for the additional selector. 
- Enhanced sidebar active-state logic in `src/components/Sidebar.tsx` by introducing `isPathActive()` and updating `useNavActive` and usages to perform prefix-aware matching so `/requirement-analysis` and its children highlight correctly. 
- No new UI dependencies were added; changes reuse existing UI components and types already present under `src/pages/RequirementAnalysis/*`. 

### Testing
- Ran TypeScript type check with `npx tsc --noEmit -p tsconfig.json`, which completed without TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef32ee39c8332800d85579c4529ea)