### PR TITLE
Add AI workbench quality coverage route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import PerformanceCases from "./pages/cases/PerformanceCases";
 import AICases from "./pages/cases/AICases";
 import AICaseCreate from "./pages/cases/AICaseCreate";
 import AICaseHistory from "./pages/cases/AICaseHistory";
+import QualityCoverage from "./pages/ai-workbench/QualityCoverage";
 import Reports from "./pages/reports/Reports";
 import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
@@ -42,6 +43,7 @@ const queryClient = new QueryClient({
 const AI_REQUIREMENT_INPUT_PATH = '/ai-workbench/requirement-input';
 const AI_CASE_GENERATION_PATH = '/ai-workbench/case-generation';
 const AI_HISTORY_EXPORT_PATH = '/ai-workbench/history-export';
+const AI_QUALITY_COVERAGE_PATH = '/ai-workbench/quality-coverage';
 
 function RedirectWithSearch({ to }: { to: string }) {
   const [, setLocation] = useLocation();
@@ -196,6 +198,13 @@ function Router() {
           <ProtectedRoute>
             <Layout>
               <AICaseHistory />
+            </Layout>
+          </ProtectedRoute>
+        </Route>
+        <Route path={AI_QUALITY_COVERAGE_PATH}>
+          <ProtectedRoute>
+            <Layout>
+              <QualityCoverage />
             </Layout>
           </ProtectedRoute>
         </Route>


### PR DESCRIPTION
### Motivation
- Expose the real QualityCoverage page under the AI workbench so users can view quality checks and coverage at `/ai-workbench/quality-coverage` behind auth and the app `Layout`.

### Description
- Import `QualityCoverage` in `src/App.tsx` and add the constant `AI_QUALITY_COVERAGE_PATH = '/ai-workbench/quality-coverage'` next to existing AI path constants.
- Register a protected route for `AI_QUALITY_COVERAGE_PATH` that wraps `QualityCoverage` with `ProtectedRoute` and `Layout` inside the existing `Switch`.
- Leave existing `/ai-workbench/requirement-input`, `/ai-workbench/case-generation`, and `/ai-workbench/history-export` behavior unchanged.

### Testing
- Ran `git diff --check` which succeeded.
- Ran `npx tsc --noEmit -p tsconfig.json` but type checking could not complete due to missing `node_modules` and unresolved types (blocked).
- Attempted `npm install --no-package-lock` but the install failed with a registry `403 Forbidden`, so full dependency installation and test suite execution were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f115ab4908332993efdb9d8ff25a7)