### PR TITLE
Use project UI components in QualityCoverage and add types

### DIFF
--- a/src/pages/ai-workbench/QualityCoverage.tsx
+++ b/src/pages/ai-workbench/QualityCoverage.tsx
@@ -5,20 +5,49 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 
-const qualityChecks = [
+type QualityResult = '通过' | '需优化' | '需补充';
+
+interface QualityCheck {
+  label: string;
+  value: number;
+  result: QualityResult;
+}
+
+interface CoverageItem {
+  name: string;
+  value: number;
+}
+
+interface PriorityItem {
+  label: string;
+  count: number;
+  className: string;
+}
+
+const qualityResultVariant: Record<QualityResult, 'success' | 'warning'> = {
+  通过: 'success',
+  需优化: 'warning',
+  需补充: 'warning',
+};
+
+const qualityChecks: QualityCheck[] = [
   { label: '步骤完整性', value: 92, result: '通过' },
   { label: '断言明确性', value: 84, result: '需优化' },
   { label: '数据可执行性', value: 78, result: '需补充' },
   { label: '重复用例检测', value: 96, result: '通过' },
 ];
-const suggestions = ['为支付超时场景补充订单状态断言。', '将库存不足和库存锁定失败拆分为两个独立用例。', '补充优惠券叠加规则的边界数据。'];
-const coverage = [
+const suggestions: string[] = [
+  '为支付超时场景补充订单状态断言。',
+  '将库存不足和库存锁定失败拆分为两个独立用例。',
+  '补充优惠券叠加规则的边界数据。',
+];
+const coverage: CoverageItem[] = [
   { name: '功能路径', value: 93 },
   { name: '异常路径', value: 81 },
   { name: '边界条件', value: 76 },
   { name: '兼容回归', value: 68 },
 ];
-const priorities = [
+const priorities: PriorityItem[] = [
   { label: 'P0', count: 28, className: 'bg-rose-500' },
   { label: 'P1', count: 46, className: 'bg-blue-500' },
   { label: 'P2', count: 31, className: 'bg-slate-400' },
@@ -30,13 +59,19 @@ export default function QualityCoverage() {
       <div className="space-y-6">
         <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
           <div>
-            <Badge variant="secondary" className="mb-3">质量覆盖</Badge>
+            <Badge variant="secondary" className="mb-3">
+              质量覆盖
+            </Badge>
             <h1 className="text-3xl font-bold tracking-tight text-slate-950 dark:text-white">质量检查与覆盖率</h1>
             <p className="mt-2 text-sm text-slate-500">检查用例质量、覆盖缺口和优先级分布。</p>
           </div>
           <div className="flex flex-wrap gap-3">
-            <Button className="gap-2"><ShieldCheck className="h-4 w-4" />一键检查质量</Button>
-            <Button variant="outline" className="gap-2"><Download className="h-4 w-4" />导出检查报告</Button>
+            <Button className="gap-2">
+              <ShieldCheck className="h-4 w-4" />一键检查质量
+            </Button>
+            <Button variant="outline" className="gap-2">
+              <Download className="h-4 w-4" />导出检查报告
+            </Button>
           </div>
         </div>
 
@@ -49,7 +84,10 @@ export default function QualityCoverage() {
             <CardContent className="space-y-4">
               {qualityChecks.map((check) => (
                 <div key={check.label} className="space-y-2 rounded-xl border p-4">
-                  <div className="flex items-center justify-between text-sm"><span className="font-semibold">{check.label}</span><Badge variant={check.result === '通过' ? 'success' : 'warning'}>{check.result}</Badge></div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="font-semibold">{check.label}</span>
+                    <Badge variant={qualityResultVariant[check.result]}>{check.result}</Badge>
+                  </div>
                   <Progress value={check.value} />
                 </div>
               ))}
@@ -58,7 +96,9 @@ export default function QualityCoverage() {
 
           <Card>
             <CardHeader>
-              <CardTitle className="flex items-center gap-2"><Lightbulb className="h-5 w-5 text-amber-500" />AI 优化建议</CardTitle>
+              <CardTitle className="flex items-center gap-2">
+                <Lightbulb className="h-5 w-5 text-amber-500" />AI 优化建议
+              </CardTitle>
               <CardDescription>建议可一键应用到用例草稿。</CardDescription>
             </CardHeader>
             <CardContent className="space-y-3">
@@ -74,13 +114,18 @@ export default function QualityCoverage() {
         <div className="grid gap-6 xl:grid-cols-2">
           <Card>
             <CardHeader>
-              <CardTitle className="flex items-center gap-2"><PieChart className="h-5 w-5 text-blue-600" />覆盖率分析</CardTitle>
+              <CardTitle className="flex items-center gap-2">
+                <PieChart className="h-5 w-5 text-blue-600" />覆盖率分析
+              </CardTitle>
               <CardDescription>定位生成结果中的覆盖薄弱点。</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               {coverage.map((item) => (
                 <div key={item.name} className="space-y-2">
-                  <div className="flex items-center justify-between text-sm"><span>{item.name}</span><span className="font-semibold">{item.value}%</span></div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span>{item.name}</span>
+                    <span className="font-semibold">{item.value}%</span>
+                  </div>
                   <Progress value={item.value} />
                 </div>
               ))}
@@ -96,7 +141,10 @@ export default function QualityCoverage() {
               {priorities.map((priority) => (
                 <div key={priority.label} className="flex items-center gap-4 rounded-xl border p-4">
                   <div className={`h-3 w-3 rounded-full ${priority.className}`} />
-                  <div className="flex-1"><div className="font-semibold">{priority.label}</div><div className="text-sm text-slate-500">{priority.count} 条用例</div></div>
+                  <div className="flex-1">
+                    <div className="font-semibold">{priority.label}</div>
+                    <div className="text-sm text-slate-500">{priority.count} 条用例</div>
+                  </div>
                   <Badge variant="outline">{Math.round((priority.count / 105) * 100)}%</Badge>
                 </div>
               ))}


### PR DESCRIPTION
### Motivation
- 保持页面 UI 与项目现有组件栈一致，避免引入 `antd` 或 `@ant-design/icons` 导致的依赖/样式不一致。 
- 通过显式 TypeScript 类型改善数据结构的可读性和维护性。 
- 提升 JSX 可读性并统一质量结果到 `Badge` 的 variant 映射以减少重复逻辑。

### Description
- 将 `QualityCoverage` 保持在项目 UI 栈中，使用本地 `@/components/ui/card`、`@/components/ui/button`、`@/components/ui/badge`、`@/components/ui/progress` 与 `lucide-react` 图标替代 Ant Design 组件。 
- 新增 `QualityResult`、`QualityCheck`、`CoverageItem`、`PriorityItem` 等 TypeScript 接口并把 `qualityChecks`、`coverage`、`priorities` 明确为这些类型。 
- 添加 `qualityResultVariant` 映射将质量结果映射为统一的 `Badge` variant，并微调 JSX 排版以提高可读性。 

### Testing
- 已运行导入检查 `rg -n "antd|@ant-design/icons" src/pages/ai-workbench/QualityCoverage.tsx`，确认未引入禁止的包（通过）。
- 运行类型检查 `npx tsc --noEmit -p tsconfig.json`，因当前环境缺少 `node_modules` 导致类型丢失而失败（阻塞，非代码错误）。
- 运行依赖安装 `npm install` 时遇到 registry 403（`@radix-ui/react-checkbox` 等包），导致无法在此环境完成完整安装和进一步测试（阻塞）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f115e9d208332b15c34bc2c4d7c66)