### PR TITLE
Add '质量检查与覆盖率' menu item under AI 工作台

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -56,6 +56,7 @@ const navItems: NavItem[] = [
     children: [
       { label: "工作台首页", href: "/ai-workbench/requirement-input", icon: <BrainCircuit className="h-4 w-4" /> },
       { label: "全部记录", href: "/ai-workbench/history-export", icon: <History className="h-4 w-4" /> },
+      { label: "质量检查与覆盖率", href: "/ai-workbench/quality-coverage", icon: <BarChart3 className="h-4 w-4" /> },
     ],
   },
   { icon: <Boxes className="h-5 w-5" />, label: "任务管理", href: "/tasks" },


### PR DESCRIPTION
### Motivation
- 在 AI 工作台侧边栏中补充质量检查与覆盖率入口，便于用户直接访问质量检查/覆盖率相关页面并保持导航一致性。

### Description
- 在 `src/components/Sidebar.tsx` 的 `navItems` 中为 `label: "AI 工作台"` 的 `children` 新增 `{ label: "质量检查与覆盖率", href: "/ai-workbench/quality-coverage", icon: <BarChart3 className="h-4 w-4" /> }`，复用已导入的 `BarChart3`（来自 `lucide-react`）。
- 未修改 `useNavActive`，其原有逻辑 `item.children?.some((c) => location === c.href)` 会使新路径和其它子项一样触发父级高亮，且不会影响现有菜单项。

### Testing
- 运行 `git diff --check`，结果通过。
- 运行 `npx tsc --noEmit -p tsconfig.json`，类型检查未通过，因为环境中缺少若干依赖/类型声明（例如 `react`、`wouter`、`lucide-react`、`@tanstack/react-query`、`vitest`），因此无法完成全量类型检查。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f115c1da08332a239b486c6fac1a3)