### PR TITLE
Replace AiWorkbenchQualityCoverage placeholder with QualityCoverage wrapper

### DIFF
--- a/src/pages/ai-workbench/AiWorkbenchQualityCoverage.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchQualityCoverage.tsx
@@ -1,11 +1,5 @@
-import AiWorkbenchPlaceholder from './AiWorkbenchPlaceholder';
+import QualityCoverage from './QualityCoverage';
 
 export default function AiWorkbenchQualityCoverage(): JSX.Element {
-  return (
-    <AiWorkbenchPlaceholder
-      title="质量检查与覆盖率"
-      description="覆盖率统计、质量检查和风险提示能力正在整合"
-      icon="chart"
-    />
-  );
+  return <QualityCoverage />;
 }


### PR DESCRIPTION
### Motivation
- Replace the placeholder that displayed “正在整合” with the real quality coverage page so the Ai Workbench route shows the implemented UX by rendering the actual `QualityCoverage` component.

### Description
- Update `src/pages/ai-workbench/AiWorkbenchQualityCoverage.tsx` to import `QualityCoverage` and return `<QualityCoverage />` instead of rendering `AiWorkbenchPlaceholder`.

### Testing
- Ran `npx tsc --noEmit -p tsconfig.json`, which failed in this environment due to missing dependencies/type declarations (for example `react`, `wouter`, `lucide-react`, `@tanstack/react-query`, and `vitest`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f115c36608332a8158bffa534c849)