### PR TITLE
Add history export workspace page for generated test cases

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ import UICases from "./pages/cases/UICases";
 import PerformanceCases from "./pages/cases/PerformanceCases";
 import AICases from "./pages/cases/AICases";
 import AICaseCreate from "./pages/cases/AICaseCreate";
-import AICaseHistory from "./pages/cases/AICaseHistory";
+import AiWorkbenchHistoryExport from "./pages/ai-workbench/AiWorkbenchHistoryExport";
 import Reports from "./pages/reports/Reports";
 import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
@@ -194,9 +194,7 @@ function Router() {
         </Route>
         <Route path={AI_HISTORY_EXPORT_PATH}>
           <ProtectedRoute>
-            <Layout>
-              <AICaseHistory />
-            </Layout>
+            <AiWorkbenchHistoryExport />
           </ProtectedRoute>
         </Route>
         <Route path="/cases/ai-create">

--- a/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
@@ -1,5 +1,11 @@
-import { useState } from 'react';
+import { BarChart3, ClipboardCheck, FileSpreadsheet, ShieldCheck } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { useLocation } from 'wouter';
+
+import { deleteWorkspaceDocument, listAllWorkspaceDocuments } from '@/lib/aiCaseStorage';
+import { computeProgress } from '@/lib/aiCaseMindMap';
+import type { AiCaseWorkspaceDocument } from '@/types/aiCases';
 
 import DetailDrawer from './history-export/components/DetailDrawer';
 import ExportCenter from './history-export/components/ExportCenter';
@@ -10,8 +16,8 @@ import StatCard from './history-export/components/StatCard';
 import SyncPanel from './history-export/components/SyncPanel';
 import VersionComparePanel from './history-export/components/VersionComparePanel';
 import VersionDiffModal from './history-export/components/VersionDiffModal';
-import { exportFormats, historyRecords, recentExports, statItems, versionRecords } from './history-export/mock';
-import type { ExportFormatOption, HistoryRecord, VersionRecord, WorkspaceTab } from './history-export/types';
+import { exportFormats, recentExports, versionRecords } from './history-export/mock';
+import type { ExportFormatOption, HistoryRecord, HistoryStatus, StatItem, VersionRecord, WorkspaceTab } from './history-export/types';
 
 const tabs: Array<{ id: WorkspaceTab; label: string }> = [
   { id: 'history', label: '生成历史' },
@@ -19,11 +25,132 @@ const tabs: Array<{ id: WorkspaceTab; label: string }> = [
   { id: 'exports', label: '导出中心' },
 ];
 
+function formatDateTime(timestamp: number): string {
+  return new Intl.DateTimeFormat('zh-CN', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(timestamp));
+}
+
+function extractRequirementName(doc: AiCaseWorkspaceDocument): string {
+  const firstLine = doc.requirement
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+
+  if (!firstLine) {
+    return '未命名需求';
+  }
+
+  return firstLine.length > 32 ? `${firstLine.slice(0, 32)}...` : firstLine;
+}
+
+function resolveHistoryStatus(doc: AiCaseWorkspaceDocument): HistoryStatus {
+  const progress = computeProgress(doc.mapData);
+
+  if (progress.failed > 0 || progress.blocked > 0) {
+    return 'failed';
+  }
+
+  if (progress.doing > 0) {
+    return 'processing';
+  }
+
+  return 'success';
+}
+
+function mapDocumentToHistoryRecord(doc: AiCaseWorkspaceDocument): HistoryRecord {
+  const progress = computeProgress(doc.mapData);
+  const syncLabel = doc.remoteWorkspaceId ? `远端工作台 #${doc.remoteWorkspaceId}` : '仅本地保存';
+
+  return {
+    id: doc.id,
+    time: formatDateTime(doc.updatedAt),
+    projectName: doc.name || 'AI Testcase Workspace',
+    requirementName: extractRequirementName(doc),
+    generatedContent: `${progress.total} 条测试点 / 已完成 ${progress.done} / 待处理 ${progress.todo}`,
+    caseCount: progress.total,
+    status: resolveHistoryStatus(doc),
+    owner: syncLabel,
+    duration: `版本 V${doc.version}`,
+    coverage: `${progress.completionRate}%`,
+    requirement: doc.requirement,
+    createdAt: formatDateTime(doc.createdAt),
+    updatedAt: formatDateTime(doc.updatedAt),
+    syncMode: doc.remoteWorkspaceId ? '已同步' : '仅本地',
+  };
+}
+
+function buildStatItems(docs: AiCaseWorkspaceDocument[]): StatItem[] {
+  const progressList = docs.map((doc) => computeProgress(doc.mapData));
+  const totalCases = progressList.reduce((sum, progress) => sum + progress.total, 0);
+  const doneCases = progressList.reduce((sum, progress) => sum + progress.done, 0);
+  const syncedDocs = docs.filter((doc) => doc.remoteWorkspaceId).length;
+  const averageCoverage = totalCases === 0 ? 0 : Math.round((doneCases / totalCases) * 100);
+
+  return [
+    { id: 'generated', label: '累计生成记录', value: `${docs.length}`, trend: '来自本地工作区历史', icon: ClipboardCheck },
+    { id: 'cases', label: '累计用例数', value: `${totalCases}`, trend: '按工作区测试点汇总', icon: BarChart3 },
+    { id: 'exports', label: '已同步工作区', value: `${syncedDocs}`, trend: `${docs.length - syncedDocs} 个仅本地保存`, icon: FileSpreadsheet },
+    { id: 'coverage', label: '平均完成率', value: `${averageCoverage}%`, trend: '基于已完成测试点计算', icon: ShieldCheck },
+  ];
+}
+
 export default function AiWorkbenchHistoryExport(): JSX.Element {
+  const [, setLocation] = useLocation();
   const [activeTab, setActiveTab] = useState<WorkspaceTab>('history');
   const [selectedRecord, setSelectedRecord] = useState<HistoryRecord | null>(null);
   const [diffOpen, setDiffOpen] = useState(false);
   const [isSyncing, setIsSyncing] = useState(false);
+  const [docs, setDocs] = useState<AiCaseWorkspaceDocument[]>([]);
+  const [loadingHistory, setLoadingHistory] = useState(true);
+
+  const loadHistory = useCallback(async (): Promise<void> => {
+    setLoadingHistory(true);
+    try {
+      setDocs(await listAllWorkspaceDocuments());
+    } catch (error) {
+      console.error('[AiWorkbenchHistoryExport] failed to load workspace history', error);
+      toast.error('加载历史记录失败，请刷新重试');
+    } finally {
+      setLoadingHistory(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadHistory();
+  }, [loadHistory]);
+
+  const historyRecords = useMemo(() => docs.map(mapDocumentToHistoryRecord), [docs]);
+  const workspaceStatItems = useMemo(() => buildStatItems(docs), [docs]);
+
+  const handleOpenRecord = useCallback(
+    (record: HistoryRecord): void => {
+      setLocation(`/ai-workbench/case-generation?docId=${encodeURIComponent(record.id)}`);
+    },
+    [setLocation]
+  );
+
+  const handleDeleteRecord = useCallback(async (record: HistoryRecord): Promise<void> => {
+    const confirmed = window.confirm(`是否确认删除「${record.projectName}」？此操作不可恢复。`);
+    if (!confirmed) {
+      return;
+    }
+
+    try {
+      await deleteWorkspaceDocument(record.id);
+      setDocs((prev) => prev.filter((doc) => doc.id !== record.id));
+      setSelectedRecord((current) => (current?.id === record.id ? null : current));
+      toast.success(`已删除「${record.projectName}」`);
+    } catch (error) {
+      console.error('[AiWorkbenchHistoryExport] failed to delete workspace history', error);
+      toast.error('删除失败，请重试');
+    }
+  }, []);
 
   const handleExport = (format: ExportFormatOption): void => {
     toast.success(`已开始导出 ${format.format} 文件`);
@@ -59,7 +186,7 @@ export default function AiWorkbenchHistoryExport(): JSX.Element {
         </div>
 
         <div className="grid grid-cols-4 gap-4">
-          {statItems.map((item) => <StatCard item={item} key={item.id} />)}
+          {workspaceStatItems.map((item) => <StatCard item={item} key={item.id} />)}
         </div>
 
         <div className="rounded-xl border border-[#E5E7EB] bg-white p-1 shadow-sm">
@@ -77,7 +204,16 @@ export default function AiWorkbenchHistoryExport(): JSX.Element {
           </div>
         </div>
 
-        {activeTab === 'history' ? <HistoryTable records={historyRecords} onViewDetail={setSelectedRecord} /> : null}
+        {activeTab === 'history' ? (
+          <HistoryTable
+            loading={loadingHistory}
+            records={historyRecords}
+            onDeleteRecord={(record) => { void handleDeleteRecord(record); }}
+            onRefresh={() => { void loadHistory(); }}
+            onResume={handleOpenRecord}
+            onViewDetail={setSelectedRecord}
+          />
+        ) : null}
         {activeTab === 'versions' ? <VersionComparePanel versions={versionRecords} onCompare={() => setDiffOpen(true)} onRestore={handleRestore} /> : null}
         {activeTab === 'exports' ? (
           <div className="space-y-6">

--- a/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
@@ -1,12 +1,96 @@
-import ComingSoon from '@/pages/ComingSoon';
-import { History } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import DetailDrawer from './history-export/components/DetailDrawer';
+import ExportCenter from './history-export/components/ExportCenter';
+import HistoryTable from './history-export/components/HistoryTable';
+import Layout from './history-export/components/Layout';
+import RecentExportList from './history-export/components/RecentExportList';
+import StatCard from './history-export/components/StatCard';
+import SyncPanel from './history-export/components/SyncPanel';
+import VersionComparePanel from './history-export/components/VersionComparePanel';
+import VersionDiffModal from './history-export/components/VersionDiffModal';
+import { exportFormats, historyRecords, recentExports, statItems, versionRecords } from './history-export/mock';
+import type { ExportFormatOption, HistoryRecord, VersionRecord, WorkspaceTab } from './history-export/types';
+
+const tabs: Array<{ id: WorkspaceTab; label: string }> = [
+  { id: 'history', label: '生成历史' },
+  { id: 'versions', label: '版本记录' },
+  { id: 'exports', label: '导出中心' },
+];
 
 export default function AiWorkbenchHistoryExport(): JSX.Element {
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>('history');
+  const [selectedRecord, setSelectedRecord] = useState<HistoryRecord | null>(null);
+  const [diffOpen, setDiffOpen] = useState(false);
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const handleExport = (format: ExportFormatOption): void => {
+    toast.success(`已开始导出 ${format.format} 文件`);
+  };
+
+  const handleRestore = (version: VersionRecord): void => {
+    const confirmed = window.confirm('是否确认恢复到该版本？');
+    if (confirmed) {
+      toast.success(`已恢复到 ${version.version}`);
+    }
+  };
+
+  const handleSync = (): void => {
+    setIsSyncing(true);
+    window.setTimeout(() => {
+      setIsSyncing(false);
+      toast.success('同步成功');
+    }, 1000);
+  };
+
   return (
-    <ComingSoon
-      title="历史记录与导出"
-      description="历史记录与导出功能正在开发中"
-      icon={<History className="h-10 w-10 text-blue-500" />}
-    />
+    <Layout>
+      <div className="mx-auto max-w-[1480px] space-y-6">
+        <div className="flex items-end justify-between">
+          <div>
+            <p className="text-sm font-semibold text-[#2563EB]">页面 6 / 6 · 历史记录与导出</p>
+            <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">历史记录与导出</h1>
+            <p className="mt-2 text-sm text-slate-500">统一管理 AI 生成历史、版本差异、导出任务与用例同步状态。</p>
+          </div>
+          <button className="rounded-xl border border-[#E5E7EB] bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:border-blue-200 hover:text-[#2563EB]" type="button">
+            导出审计日志
+          </button>
+        </div>
+
+        <div className="grid grid-cols-4 gap-4">
+          {statItems.map((item) => <StatCard item={item} key={item.id} />)}
+        </div>
+
+        <div className="rounded-xl border border-[#E5E7EB] bg-white p-1 shadow-sm">
+          <div className="flex gap-1">
+            {tabs.map((tab) => (
+              <button
+                className={`rounded-lg px-5 py-2.5 text-sm font-semibold transition ${activeTab === tab.id ? 'bg-[#2563EB] text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900'}`}
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {activeTab === 'history' ? <HistoryTable records={historyRecords} onViewDetail={setSelectedRecord} /> : null}
+        {activeTab === 'versions' ? <VersionComparePanel versions={versionRecords} onCompare={() => setDiffOpen(true)} onRestore={handleRestore} /> : null}
+        {activeTab === 'exports' ? (
+          <div className="space-y-6">
+            <ExportCenter formats={exportFormats} onExport={handleExport} />
+            <div className="grid grid-cols-[1fr_0.85fr] gap-6">
+              <RecentExportList exports={recentExports} />
+              <SyncPanel isSyncing={isSyncing} onSync={handleSync} />
+            </div>
+          </div>
+        ) : null}
+      </div>
+      <DetailDrawer record={selectedRecord} onClose={() => setSelectedRecord(null)} />
+      <VersionDiffModal open={diffOpen} onClose={() => setDiffOpen(false)} />
+    </Layout>
   );
 }

--- a/src/pages/ai-workbench/history-export/components/DetailDrawer.tsx
+++ b/src/pages/ai-workbench/history-export/components/DetailDrawer.tsx
@@ -16,13 +16,15 @@ export default function DetailDrawer({ record, onClose }: DetailDrawerProps): JS
   const detailRows = [
     { label: '记录编号', value: record.id },
     { label: '生成时间', value: record.time },
+    { label: '创建时间', value: record.createdAt ?? record.time },
     { label: '项目名称', value: record.projectName },
     { label: '需求名称', value: record.requirementName },
     { label: '生成内容', value: record.generatedContent },
     { label: '用例数量', value: `${record.caseCount} 条` },
-    { label: '负责人', value: record.owner },
+    { label: '保存位置', value: record.owner },
     { label: '生成耗时', value: record.duration },
-    { label: '覆盖率', value: record.coverage },
+    { label: '完成率', value: record.coverage },
+    { label: '同步状态', value: record.syncMode ?? '仅本地' },
   ];
 
   return (
@@ -44,6 +46,10 @@ export default function DetailDrawer({ record, onClose }: DetailDrawerProps): JS
               <div className="mt-1 text-sm font-semibold text-slate-900">{row.value}</div>
             </div>
           ))}
+          <div className="rounded-xl border border-[#E5E7EB] p-3">
+            <div className="text-xs font-semibold text-slate-400">需求原文</div>
+            <div className="mt-1 max-h-32 overflow-y-auto whitespace-pre-wrap text-sm font-medium text-slate-700">{record.requirement ?? '暂无需求原文'}</div>
+          </div>
           <div className="rounded-xl border border-[#E5E7EB] p-3">
             <div className="text-xs font-semibold text-slate-400">状态</div>
             <div className="mt-2"><StatusTag status={record.status} /></div>

--- a/src/pages/ai-workbench/history-export/components/DetailDrawer.tsx
+++ b/src/pages/ai-workbench/history-export/components/DetailDrawer.tsx
@@ -1,0 +1,55 @@
+import { X } from 'lucide-react';
+
+import type { HistoryRecord } from '../types';
+import StatusTag from './StatusTag';
+
+export interface DetailDrawerProps {
+  record: HistoryRecord | null;
+  onClose: () => void;
+}
+
+export default function DetailDrawer({ record, onClose }: DetailDrawerProps): JSX.Element | null {
+  if (!record) {
+    return null;
+  }
+
+  const detailRows = [
+    { label: '记录编号', value: record.id },
+    { label: '生成时间', value: record.time },
+    { label: '项目名称', value: record.projectName },
+    { label: '需求名称', value: record.requirementName },
+    { label: '生成内容', value: record.generatedContent },
+    { label: '用例数量', value: `${record.caseCount} 条` },
+    { label: '负责人', value: record.owner },
+    { label: '生成耗时', value: record.duration },
+    { label: '覆盖率', value: record.coverage },
+  ];
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-slate-950/30">
+      <aside className="h-full w-[440px] bg-white p-6 shadow-2xl">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-slate-950">历史记录详情</h2>
+            <p className="mt-1 text-sm text-slate-500">查看当前记录的生成参数、结果与状态。</p>
+          </div>
+          <button className="rounded-lg border border-[#E5E7EB] p-2 text-slate-500 hover:text-slate-900" type="button" onClick={onClose} aria-label="关闭详情">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="mt-6 space-y-3">
+          {detailRows.map((row) => (
+            <div className="rounded-xl border border-[#E5E7EB] p-3" key={row.label}>
+              <div className="text-xs font-semibold text-slate-400">{row.label}</div>
+              <div className="mt-1 text-sm font-semibold text-slate-900">{row.value}</div>
+            </div>
+          ))}
+          <div className="rounded-xl border border-[#E5E7EB] p-3">
+            <div className="text-xs font-semibold text-slate-400">状态</div>
+            <div className="mt-2"><StatusTag status={record.status} /></div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/ExportCenter.tsx
+++ b/src/pages/ai-workbench/history-export/components/ExportCenter.tsx
@@ -1,0 +1,31 @@
+import type { ExportFormatOption } from '../types';
+
+export interface ExportCenterProps {
+  formats: ExportFormatOption[];
+  onExport: (format: ExportFormatOption) => void;
+}
+
+export default function ExportCenter({ formats, onExport }: ExportCenterProps): JSX.Element {
+  return (
+    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div className="mb-5">
+        <h2 className="text-lg font-bold text-slate-950">导出中心</h2>
+        <p className="mt-1 text-sm text-slate-500">选择 Excel、Markdown、JSON、PDF 四种格式生成下载任务。</p>
+      </div>
+      <div className="grid grid-cols-4 gap-4">
+        {formats.map((format) => {
+          const Icon = format.icon;
+          return (
+            <button className="rounded-xl border border-[#E5E7EB] bg-white p-4 text-left transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md" key={format.format} type="button" onClick={() => onExport(format)}>
+              <span className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-blue-50 text-[#2563EB]">
+                <Icon className="h-5 w-5" />
+              </span>
+              <span className="block text-base font-bold text-slate-950">{format.title}</span>
+              <span className="mt-2 block text-sm leading-6 text-slate-500">{format.description}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/Header.tsx
+++ b/src/pages/ai-workbench/history-export/components/Header.tsx
@@ -1,0 +1,42 @@
+import { Bell, ChevronDown, CircleHelp, Search, Sparkles } from 'lucide-react';
+
+export default function Header(): JSX.Element {
+  return (
+    <header className="flex h-16 items-center justify-between border-b border-[#E5E7EB] bg-white px-6">
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-3">
+          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-[#2563EB] text-white shadow-sm">
+            <Sparkles className="h-5 w-5" />
+          </span>
+          <span className="text-base font-bold text-slate-950">AI 测试用例生成工作台</span>
+        </div>
+        <button className="flex items-center gap-2 rounded-xl border border-[#E5E7EB] bg-white px-3 py-2 text-sm font-medium text-slate-700" type="button">
+          示例项目 <ChevronDown className="h-4 w-4 text-slate-400" />
+        </button>
+      </div>
+      <div className="mx-8 flex max-w-xl flex-1 items-center rounded-xl border border-[#E5E7EB] bg-[#F8FAFC] px-3 py-2">
+        <Search className="h-4 w-4 text-slate-400" />
+        <input
+          className="ml-2 w-full bg-transparent text-sm text-slate-700 outline-none placeholder:text-slate-400"
+          placeholder="搜索需求、项目、用例、测试点..."
+          type="search"
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <button className="rounded-xl border border-[#E5E7EB] p-2 text-slate-500 hover:text-[#2563EB]" type="button" aria-label="通知">
+          <Bell className="h-5 w-5" />
+        </button>
+        <button className="rounded-xl border border-[#E5E7EB] p-2 text-slate-500 hover:text-[#2563EB]" type="button" aria-label="帮助">
+          <CircleHelp className="h-5 w-5" />
+        </button>
+        <div className="flex items-center gap-3 rounded-xl border border-[#E5E7EB] px-3 py-1.5">
+          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-[#2563EB]">张</div>
+          <div className="leading-tight">
+            <div className="text-sm font-semibold text-slate-900">张伟</div>
+            <div className="text-xs text-slate-500">测试工程师</div>
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/Header.tsx
+++ b/src/pages/ai-workbench/history-export/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Bell, ChevronDown, CircleHelp, Search, Sparkles } from 'lucide-react';
+import { Bell, ChevronDown, HelpCircle, Search, Sparkles } from 'lucide-react';
 
 export default function Header(): JSX.Element {
   return (
@@ -27,7 +27,7 @@ export default function Header(): JSX.Element {
           <Bell className="h-5 w-5" />
         </button>
         <button className="rounded-xl border border-[#E5E7EB] p-2 text-slate-500 hover:text-[#2563EB]" type="button" aria-label="帮助">
-          <CircleHelp className="h-5 w-5" />
+          <HelpCircle className="h-5 w-5" />
         </button>
         <div className="flex items-center gap-3 rounded-xl border border-[#E5E7EB] px-3 py-1.5">
           <div className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-100 text-sm font-bold text-[#2563EB]">张</div>

--- a/src/pages/ai-workbench/history-export/components/HistoryTable.tsx
+++ b/src/pages/ai-workbench/history-export/components/HistoryTable.tsx
@@ -1,28 +1,65 @@
-import { Eye } from 'lucide-react';
+import { Eye, PlayCircle, RefreshCw, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { HistoryRecord } from '../types';
 import Pagination from './Pagination';
 import StatusTag from './StatusTag';
 
+const PAGE_SIZE = 10;
+
 export interface HistoryTableProps {
   records: HistoryRecord[];
+  loading: boolean;
+  onDeleteRecord: (record: HistoryRecord) => void;
+  onRefresh: () => void;
+  onResume: (record: HistoryRecord) => void;
   onViewDetail: (record: HistoryRecord) => void;
 }
 
-export default function HistoryTable({ records, onViewDetail }: HistoryTableProps): JSX.Element {
+export default function HistoryTable({
+  records,
+  loading,
+  onDeleteRecord,
+  onRefresh,
+  onResume,
+  onViewDetail,
+}: HistoryTableProps): JSX.Element {
+  const [page, setPage] = useState(1);
+  const totalPages = Math.max(1, Math.ceil(records.length / PAGE_SIZE));
+  const safePage = Math.min(page, totalPages);
+  const pagedRecords = useMemo(() => {
+    const start = (safePage - 1) * PAGE_SIZE;
+    return records.slice(start, start + PAGE_SIZE);
+  }, [records, safePage]);
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
+
   return (
     <section className="overflow-hidden rounded-xl border border-[#E5E7EB] bg-white shadow-sm">
       <div className="flex items-center justify-between px-5 py-4">
         <div>
           <h2 className="text-lg font-bold text-slate-950">生成历史</h2>
-          <p className="mt-1 text-sm text-slate-500">展示最近 8 条历史生成记录，支持查看生成详情。</p>
+          <p className="mt-1 text-sm text-slate-500">展示本地保存的 AI 工作区历史，支持查看详情、继续编辑和删除。</p>
         </div>
+        <button
+          className="inline-flex items-center gap-1.5 rounded-lg border border-[#E5E7EB] bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:border-blue-200 hover:text-[#2563EB] disabled:cursor-not-allowed disabled:opacity-60"
+          type="button"
+          onClick={onRefresh}
+          disabled={loading}
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          刷新
+        </button>
       </div>
       <table className="w-full text-left text-sm">
         <thead className="bg-[#F8FAFC] text-xs font-semibold uppercase tracking-wide text-slate-500">
           <tr>
-            <th className="px-5 py-3">时间</th>
-            <th className="px-5 py-3">项目名称</th>
+            <th className="px-5 py-3">更新时间</th>
+            <th className="px-5 py-3">工作区名称</th>
             <th className="px-5 py-3">需求名称</th>
             <th className="px-5 py-3">生成内容</th>
             <th className="px-5 py-3">用例数</th>
@@ -31,7 +68,7 @@ export default function HistoryTable({ records, onViewDetail }: HistoryTableProp
           </tr>
         </thead>
         <tbody className="divide-y divide-[#E5E7EB]">
-          {records.map((record) => (
+          {pagedRecords.map((record) => (
             <tr className="hover:bg-blue-50/30" key={record.id}>
               <td className="whitespace-nowrap px-5 py-4 text-slate-600">{record.time}</td>
               <td className="px-5 py-4 font-semibold text-slate-900">{record.projectName}</td>
@@ -40,15 +77,37 @@ export default function HistoryTable({ records, onViewDetail }: HistoryTableProp
               <td className="px-5 py-4 font-semibold text-slate-900">{record.caseCount}</td>
               <td className="px-5 py-4"><StatusTag status={record.status} /></td>
               <td className="px-5 py-4">
-                <button className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold text-[#2563EB] hover:bg-blue-50" type="button" onClick={() => onViewDetail(record)}>
-                  <Eye className="h-4 w-4" />查看详情
-                </button>
+                <div className="flex items-center gap-1">
+                  <button className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold text-[#2563EB] hover:bg-blue-50" type="button" onClick={() => onViewDetail(record)}>
+                    <Eye className="h-4 w-4" />详情
+                  </button>
+                  <button className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold text-emerald-700 hover:bg-emerald-50" type="button" onClick={() => onResume(record)}>
+                    <PlayCircle className="h-4 w-4" />继续
+                  </button>
+                  <button className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold text-red-600 hover:bg-red-50" type="button" onClick={() => onDeleteRecord(record)}>
+                    <Trash2 className="h-4 w-4" />删除
+                  </button>
+                </div>
               </td>
             </tr>
           ))}
+          {!loading && records.length === 0 ? (
+            <tr>
+              <td className="px-5 py-12 text-center text-sm text-slate-500" colSpan={7}>
+                暂无本地 AI 工作区历史。生成用例后，记录会自动保存在这里。
+              </td>
+            </tr>
+          ) : null}
+          {loading ? (
+            <tr>
+              <td className="px-5 py-12 text-center text-sm text-slate-500" colSpan={7}>
+                正在加载本地历史记录...
+              </td>
+            </tr>
+          ) : null}
         </tbody>
       </table>
-      <Pagination />
+      <Pagination currentPage={safePage} pageSize={PAGE_SIZE} total={records.length} totalPages={totalPages} onPageChange={setPage} />
     </section>
   );
 }

--- a/src/pages/ai-workbench/history-export/components/HistoryTable.tsx
+++ b/src/pages/ai-workbench/history-export/components/HistoryTable.tsx
@@ -1,0 +1,54 @@
+import { Eye } from 'lucide-react';
+
+import type { HistoryRecord } from '../types';
+import Pagination from './Pagination';
+import StatusTag from './StatusTag';
+
+export interface HistoryTableProps {
+  records: HistoryRecord[];
+  onViewDetail: (record: HistoryRecord) => void;
+}
+
+export default function HistoryTable({ records, onViewDetail }: HistoryTableProps): JSX.Element {
+  return (
+    <section className="overflow-hidden rounded-xl border border-[#E5E7EB] bg-white shadow-sm">
+      <div className="flex items-center justify-between px-5 py-4">
+        <div>
+          <h2 className="text-lg font-bold text-slate-950">生成历史</h2>
+          <p className="mt-1 text-sm text-slate-500">展示最近 8 条历史生成记录，支持查看生成详情。</p>
+        </div>
+      </div>
+      <table className="w-full text-left text-sm">
+        <thead className="bg-[#F8FAFC] text-xs font-semibold uppercase tracking-wide text-slate-500">
+          <tr>
+            <th className="px-5 py-3">时间</th>
+            <th className="px-5 py-3">项目名称</th>
+            <th className="px-5 py-3">需求名称</th>
+            <th className="px-5 py-3">生成内容</th>
+            <th className="px-5 py-3">用例数</th>
+            <th className="px-5 py-3">状态</th>
+            <th className="px-5 py-3">操作</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-[#E5E7EB]">
+          {records.map((record) => (
+            <tr className="hover:bg-blue-50/30" key={record.id}>
+              <td className="whitespace-nowrap px-5 py-4 text-slate-600">{record.time}</td>
+              <td className="px-5 py-4 font-semibold text-slate-900">{record.projectName}</td>
+              <td className="px-5 py-4 text-slate-700">{record.requirementName}</td>
+              <td className="max-w-xs px-5 py-4 text-slate-600">{record.generatedContent}</td>
+              <td className="px-5 py-4 font-semibold text-slate-900">{record.caseCount}</td>
+              <td className="px-5 py-4"><StatusTag status={record.status} /></td>
+              <td className="px-5 py-4">
+                <button className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-semibold text-[#2563EB] hover:bg-blue-50" type="button" onClick={() => onViewDetail(record)}>
+                  <Eye className="h-4 w-4" />查看详情
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Pagination />
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/Layout.tsx
+++ b/src/pages/ai-workbench/history-export/components/Layout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+import Header from './Header';
+import Sidebar from './Sidebar';
+
+export interface LayoutProps {
+  children: ReactNode;
+}
+
+export default function Layout({ children }: LayoutProps): JSX.Element {
+  return (
+    <div className="min-h-screen bg-[#F8FAFC] text-slate-900">
+      <Header />
+      <div className="flex min-h-[calc(100vh-4rem)]">
+        <Sidebar />
+        <main className="min-w-0 flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/Pagination.tsx
+++ b/src/pages/ai-workbench/history-export/components/Pagination.tsx
@@ -1,26 +1,54 @@
-export default function Pagination(): JSX.Element {
-  const pages = ['1', '2', '3', '4', '5', '...', '25'];
+export interface PaginationProps {
+  currentPage: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export default function Pagination({ currentPage, pageSize, total, totalPages, onPageChange }: PaginationProps): JSX.Element {
+  const pages = Array.from({ length: Math.min(totalPages, 6) }, (_, index) => `${index + 1}`);
+  const displayedPages = totalPages > 6 ? [...pages.slice(0, 5), '...', `${totalPages}`] : pages;
+
   return (
     <div className="flex items-center justify-between border-t border-[#E5E7EB] px-5 py-4 text-sm text-slate-600">
-      <span>共 248 条</span>
+      <span>共 {total} 条</span>
       <div className="flex items-center gap-2">
-        {pages.map((page) => (
+        {displayedPages.map((page) => (
           <button
             className={`h-8 min-w-8 rounded-lg border px-2 font-medium ${
-              page === '1' ? 'border-[#2563EB] bg-[#2563EB] text-white' : 'border-[#E5E7EB] bg-white text-slate-600 hover:border-blue-200 hover:text-[#2563EB]'
+              page === `${currentPage}` ? 'border-[#2563EB] bg-[#2563EB] text-white' : 'border-[#E5E7EB] bg-white text-slate-600 hover:border-blue-200 hover:text-[#2563EB]'
             }`}
             key={page}
             type="button"
+            disabled={page === '...'}
+            onClick={() => {
+              if (page !== '...') {
+                onPageChange(Number(page));
+              }
+            }}
           >
             {page}
           </button>
         ))}
       </div>
       <div className="flex items-center gap-3">
-        <span>10 条 / 页</span>
+        <span>{pageSize} 条 / 页</span>
         <label className="flex items-center gap-2">
           跳转
-          <input className="h-8 w-14 rounded-lg border border-[#E5E7EB] px-2 text-center outline-none focus:border-[#2563EB]" type="text" />
+          <input
+            className="h-8 w-14 rounded-lg border border-[#E5E7EB] px-2 text-center outline-none focus:border-[#2563EB]"
+            type="number"
+            min={1}
+            max={totalPages}
+            value={currentPage}
+            onChange={(event) => {
+              const nextPage = Number(event.target.value);
+              if (Number.isInteger(nextPage) && nextPage >= 1 && nextPage <= totalPages) {
+                onPageChange(nextPage);
+              }
+            }}
+          />
           页
         </label>
       </div>

--- a/src/pages/ai-workbench/history-export/components/Pagination.tsx
+++ b/src/pages/ai-workbench/history-export/components/Pagination.tsx
@@ -1,0 +1,29 @@
+export default function Pagination(): JSX.Element {
+  const pages = ['1', '2', '3', '4', '5', '...', '25'];
+  return (
+    <div className="flex items-center justify-between border-t border-[#E5E7EB] px-5 py-4 text-sm text-slate-600">
+      <span>共 248 条</span>
+      <div className="flex items-center gap-2">
+        {pages.map((page) => (
+          <button
+            className={`h-8 min-w-8 rounded-lg border px-2 font-medium ${
+              page === '1' ? 'border-[#2563EB] bg-[#2563EB] text-white' : 'border-[#E5E7EB] bg-white text-slate-600 hover:border-blue-200 hover:text-[#2563EB]'
+            }`}
+            key={page}
+            type="button"
+          >
+            {page}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-3">
+        <span>10 条 / 页</span>
+        <label className="flex items-center gap-2">
+          跳转
+          <input className="h-8 w-14 rounded-lg border border-[#E5E7EB] px-2 text-center outline-none focus:border-[#2563EB]" type="text" />
+          页
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/RecentExportList.tsx
+++ b/src/pages/ai-workbench/history-export/components/RecentExportList.tsx
@@ -1,0 +1,31 @@
+import { Download } from 'lucide-react';
+
+import type { RecentExport } from '../types';
+
+export interface RecentExportListProps {
+  exports: RecentExport[];
+}
+
+export default function RecentExportList({ exports }: RecentExportListProps): JSX.Element {
+  return (
+    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-bold text-slate-950">最近导出记录</h2>
+      <div className="mt-4 space-y-3">
+        {exports.map((item) => (
+          <div className="flex items-center justify-between rounded-xl border border-[#E5E7EB] p-3" key={item.id}>
+            <div>
+              <div className="font-semibold text-slate-900">{item.fileName}</div>
+              <div className="mt-1 text-xs text-slate-500">{item.format} · {item.time} · {item.size}</div>
+            </div>
+            <div className="flex items-center gap-3">
+              <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${item.status === '完成' ? 'bg-emerald-50 text-emerald-700' : 'bg-orange-50 text-orange-700'}`}>{item.status}</span>
+              <button className="rounded-lg border border-[#E5E7EB] p-2 text-slate-500 hover:text-[#2563EB]" type="button" aria-label={`下载 ${item.fileName}`}>
+                <Download className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/Sidebar.tsx
+++ b/src/pages/ai-workbench/history-export/components/Sidebar.tsx
@@ -1,0 +1,37 @@
+import { BarChart3, ClipboardList, FileInput, History, LayoutDashboard, Settings, ShieldCheck } from 'lucide-react';
+
+const menuItems = [
+  { label: '工作台总览', icon: LayoutDashboard },
+  { label: '需求输入与解析', icon: FileInput },
+  { label: '需求分析与测试点', icon: ClipboardList },
+  { label: '用例生成与编辑', icon: BarChart3 },
+  { label: '质量检查与覆盖率', icon: ShieldCheck },
+  { label: '历史记录与导出', icon: History },
+  { label: '设置', icon: Settings },
+];
+
+export default function Sidebar(): JSX.Element {
+  return (
+    <aside className="w-64 shrink-0 border-r border-[#E5E7EB] bg-white px-4 py-5">
+      <div className="mb-5 px-2 text-xs font-semibold uppercase tracking-[0.24em] text-slate-400">Workspace</div>
+      <nav className="space-y-2">
+        {menuItems.map((item) => {
+          const Icon = item.icon;
+          const active = item.label === '历史记录与导出';
+          return (
+            <button
+              className={`flex w-full items-center gap-3 rounded-xl px-3 py-3 text-left text-sm font-semibold transition ${
+                active ? 'bg-blue-50 text-[#2563EB] shadow-sm ring-1 ring-blue-100' : 'text-slate-600 hover:bg-slate-50 hover:text-slate-900'
+              }`}
+              key={item.label}
+              type="button"
+            >
+              <Icon className="h-5 w-5" />
+              {item.label}
+            </button>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/StatCard.tsx
+++ b/src/pages/ai-workbench/history-export/components/StatCard.tsx
@@ -1,0 +1,23 @@
+import type { StatItem } from '../types';
+
+export interface StatCardProps {
+  item: StatItem;
+}
+
+export default function StatCard({ item }: StatCardProps): JSX.Element {
+  const Icon = item.icon;
+  return (
+    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-sm text-slate-500">{item.label}</p>
+          <p className="mt-2 text-3xl font-bold tracking-tight text-slate-950">{item.value}</p>
+        </div>
+        <span className="flex h-11 w-11 items-center justify-center rounded-xl bg-blue-50 text-[#2563EB]">
+          <Icon className="h-5 w-5" />
+        </span>
+      </div>
+      <p className="mt-4 text-sm font-medium text-emerald-600">{item.trend}</p>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/StatusTag.tsx
+++ b/src/pages/ai-workbench/history-export/components/StatusTag.tsx
@@ -1,0 +1,25 @@
+import type { HistoryStatus } from '../types';
+
+const statusStyles: Record<HistoryStatus, string> = {
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  processing: 'border-orange-200 bg-orange-50 text-orange-700',
+  failed: 'border-red-200 bg-red-50 text-red-700',
+};
+
+const statusLabels: Record<HistoryStatus, string> = {
+  success: '生成成功',
+  processing: '生成中',
+  failed: '生成失败',
+};
+
+export interface StatusTagProps {
+  status: HistoryStatus;
+}
+
+export default function StatusTag({ status }: StatusTagProps): JSX.Element {
+  return (
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold ${statusStyles[status]}`}>
+      {statusLabels[status]}
+    </span>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/SyncPanel.tsx
+++ b/src/pages/ai-workbench/history-export/components/SyncPanel.tsx
@@ -1,0 +1,28 @@
+import { Loader2, RefreshCw } from 'lucide-react';
+
+export interface SyncPanelProps {
+  isSyncing: boolean;
+  onSync: () => void;
+}
+
+export default function SyncPanel({ isSyncing, onSync }: SyncPanelProps): JSX.Element {
+  return (
+    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-bold text-slate-950">同步用例</h2>
+          <p className="mt-1 text-sm text-slate-500">将已确认用例同步到测试管理平台，并保留同步日志。</p>
+        </div>
+        <button className="inline-flex items-center gap-2 rounded-xl bg-[#2563EB] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-70" disabled={isSyncing} type="button" onClick={onSync}>
+          {isSyncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+          {isSyncing ? '同步中...' : '同步用例'}
+        </button>
+      </div>
+      <div className="mt-5 grid grid-cols-3 gap-3 text-sm">
+        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">目标空间</span><div className="mt-1 font-semibold text-slate-900">示例项目 / AI Case Space</div></div>
+        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">待同步</span><div className="mt-1 font-semibold text-slate-900">128 条用例</div></div>
+        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">最近同步</span><div className="mt-1 font-semibold text-slate-900">2026-06-01 17:45</div></div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/VersionComparePanel.tsx
+++ b/src/pages/ai-workbench/history-export/components/VersionComparePanel.tsx
@@ -1,0 +1,53 @@
+import { RotateCcw } from 'lucide-react';
+
+import type { VersionRecord } from '../types';
+
+export interface VersionComparePanelProps {
+  versions: VersionRecord[];
+  onCompare: () => void;
+  onRestore: (version: VersionRecord) => void;
+}
+
+export default function VersionComparePanel({ versions, onCompare, onRestore }: VersionComparePanelProps): JSX.Element {
+  return (
+    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div className="mb-5 flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-bold text-slate-950">版本记录</h2>
+          <p className="mt-1 text-sm text-slate-500">以时间线方式追踪最近 3 条版本记录与差异摘要。</p>
+        </div>
+        <button className="rounded-xl bg-[#2563EB] px-4 py-2 text-sm font-semibold text-white shadow-sm" type="button" onClick={onCompare}>
+          对比版本差异
+        </button>
+      </div>
+      <div className="relative space-y-4 before:absolute before:bottom-6 before:left-5 before:top-6 before:w-px before:bg-[#E5E7EB]">
+        {versions.map((version) => (
+          <article className={`relative ml-2 rounded-xl border bg-white p-4 pl-8 ${version.isCurrent ? 'border-[#2563EB] shadow-sm shadow-blue-100' : 'border-[#E5E7EB]'}`} key={version.id}>
+            <span className={`absolute -left-0.5 top-5 h-3 w-3 rounded-full ring-4 ${version.isCurrent ? 'bg-[#2563EB] ring-blue-100' : 'bg-slate-300 ring-white'}`} />
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2">
+                  <h3 className="text-base font-bold text-slate-950">{version.version} · {version.title}</h3>
+                  {version.isCurrent ? <span className="rounded-full bg-blue-50 px-2 py-0.5 text-xs font-semibold text-[#2563EB]">当前版本</span> : null}
+                </div>
+                <p className="mt-2 text-sm text-slate-600">{version.summary}</p>
+                <p className="mt-3 text-xs text-slate-400">{version.time} · {version.author}</p>
+              </div>
+              <div className="flex shrink-0 gap-2">
+                <button className="rounded-lg border border-[#E5E7EB] px-3 py-2 text-sm font-semibold text-slate-700 hover:border-blue-200 hover:text-[#2563EB]" type="button">
+                  查看详情
+                </button>
+                <button className="inline-flex items-center gap-1.5 rounded-lg border border-[#E5E7EB] px-3 py-2 text-sm font-semibold text-slate-700 hover:border-orange-200 hover:text-orange-600" type="button" onClick={() => onRestore(version)}>
+                  <RotateCcw className="h-4 w-4" />恢复版本
+                </button>
+                <button className="rounded-lg bg-[#2563EB] px-3 py-2 text-sm font-semibold text-white" type="button" onClick={onCompare}>
+                  对比版本差异
+                </button>
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/VersionDiffModal.tsx
+++ b/src/pages/ai-workbench/history-export/components/VersionDiffModal.tsx
@@ -1,0 +1,41 @@
+import { X } from 'lucide-react';
+
+import { diffSummary } from '../mock';
+
+export interface VersionDiffModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function VersionDiffModal({ open, onClose }: VersionDiffModalProps): JSX.Element | null {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40">
+      <section className="w-[520px] rounded-xl bg-white p-6 shadow-2xl">
+        <div className="flex items-start justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-slate-950">版本差异对比</h2>
+            <p className="mt-1 text-sm text-slate-500">V1.2 与上一版本的用例变化概览。</p>
+          </div>
+          <button className="rounded-lg border border-[#E5E7EB] p-2 text-slate-500 hover:text-slate-900" type="button" onClick={onClose} aria-label="关闭差异对比">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="mt-6 grid grid-cols-3 gap-3">
+          {diffSummary.map((item) => (
+            <div className={`rounded-xl p-4 text-center ${item.tone}`} key={item.label}>
+              <div className="text-sm font-semibold">{item.label}</div>
+              <div className="mt-2 text-2xl font-bold">{item.value}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-6 rounded-xl border border-[#E5E7EB] bg-[#F8FAFC] p-4 text-sm leading-6 text-slate-600">
+          本次变更集中在订单支付、库存回滚、消息补偿 3 个模块，建议优先执行新增高优先级用例。
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/pages/ai-workbench/history-export/mock.ts
+++ b/src/pages/ai-workbench/history-export/mock.ts
@@ -1,0 +1,49 @@
+import { BarChart3, ClipboardCheck, FileJson, FileSpreadsheet, FileText, GitCompareArrows, ShieldCheck, TrendingUp } from 'lucide-react';
+
+import type { ExportFormatOption, HistoryRecord, RecentExport, StatItem, VersionRecord } from './types';
+
+export const statItems: StatItem[] = [
+  { id: 'generated', label: '累计生成记录', value: '248', trend: '较上周 +12.5%', icon: ClipboardCheck },
+  { id: 'cases', label: '累计用例数', value: '8,642', trend: '本月新增 1,280 条', icon: BarChart3 },
+  { id: 'exports', label: '导出任务', value: '136', trend: '成功率 99.2%', icon: FileSpreadsheet },
+  { id: 'coverage', label: '平均覆盖率', value: '94.8%', trend: '稳定提升 3.1%', icon: ShieldCheck },
+];
+
+export const historyRecords: HistoryRecord[] = [
+  { id: 'HIS-20260601-001', time: '2026-06-01 17:30', projectName: '示例项目', requirementName: '订单结算流程优化', generatedContent: '接口用例 / 异常场景 / 回归套件', caseCount: 128, status: 'success', owner: '张伟', duration: '2 分 18 秒', coverage: '96%' },
+  { id: 'HIS-20260531-014', time: '2026-05-31 15:12', projectName: '示例项目', requirementName: '会员权益配置后台', generatedContent: '功能用例 / 权限校验 / 边界值', caseCount: 86, status: 'processing', owner: '李娜', duration: '生成中', coverage: '91%' },
+  { id: 'HIS-20260530-009', time: '2026-05-30 10:45', projectName: '支付中台', requirementName: '支付渠道路由策略', generatedContent: '接口用例 / 幂等验证 / 监控校验', caseCount: 142, status: 'success', owner: '王强', duration: '3 分 02 秒', coverage: '98%' },
+  { id: 'HIS-20260529-021', time: '2026-05-29 19:04', projectName: '营销平台', requirementName: '优惠券批量发放', generatedContent: '批处理用例 / 风控规则 / 数据核对', caseCount: 74, status: 'failed', owner: '陈晨', duration: '58 秒', coverage: '73%' },
+  { id: 'HIS-20260528-018', time: '2026-05-28 14:26', projectName: '开放平台', requirementName: '开放 API 鉴权升级', generatedContent: '安全用例 / 签名校验 / 兼容性', caseCount: 118, status: 'success', owner: '周敏', duration: '2 分 46 秒', coverage: '95%' },
+  { id: 'HIS-20260527-016', time: '2026-05-27 11:18', projectName: '示例项目', requirementName: '客服工单智能分派', generatedContent: '流程用例 / SLA 校验 / 异常兜底', caseCount: 92, status: 'success', owner: '张伟', duration: '2 分 05 秒', coverage: '93%' },
+  { id: 'HIS-20260526-011', time: '2026-05-26 16:50', projectName: '数据资产', requirementName: '指标血缘追踪', generatedContent: '数据校验 / 权限矩阵 / 审计日志', caseCount: 64, status: 'processing', owner: '赵磊', duration: '生成中', coverage: '89%' },
+  { id: 'HIS-20260525-007', time: '2026-05-25 09:36', projectName: '移动端 App', requirementName: '登录态续期策略', generatedContent: '端到端用例 / 弱网场景 / 安全校验', caseCount: 105, status: 'success', owner: '孙悦', duration: '2 分 31 秒', coverage: '97%' },
+];
+
+export const versionRecords: VersionRecord[] = [
+  { id: 'VER-12', version: 'V1.2', title: '补充异常断言与自动化脚本映射', time: '2026-06-01 17:30', author: '张伟', summary: '当前版本：新增支付失败、库存回滚、重试补偿等高优先级用例。', isCurrent: true },
+  { id: 'VER-11', version: 'V1.1', title: '完善核心链路与权限边界', time: '2026-05-30 18:20', author: '李娜', summary: '根据评审意见补充管理员、普通用户、访客三类权限矩阵。', isCurrent: false },
+  { id: 'VER-10', version: 'V1.0', title: '首次生成需求测试用例集', time: '2026-05-28 10:00', author: 'AI Copilot', summary: '基于需求原文生成冒烟、功能、接口、异常与回归用例。', isCurrent: false },
+];
+
+export const exportFormats: ExportFormatOption[] = [
+  { format: 'Excel', title: '导出 Excel', description: '适合导入测试管理平台，包含步骤、预期与优先级。', icon: FileSpreadsheet },
+  { format: 'Markdown', title: '导出 Markdown', description: '适合评审纪要、知识库和研发协作文档沉淀。', icon: FileText },
+  { format: 'JSON', title: '导出 JSON', description: '适合自动化流水线、接口平台和二次开发消费。', icon: FileJson },
+  { format: 'PDF', title: '导出 PDF', description: '适合归档、外部审阅和测试交付报告输出。', icon: TrendingUp },
+];
+
+export const recentExports: RecentExport[] = [
+  { id: 'EXP-001', fileName: '订单结算流程优化_用例集.xlsx', format: 'Excel', time: '2026-06-01 17:42', size: '2.4 MB', status: '完成' },
+  { id: 'EXP-002', fileName: '会员权益配置后台_评审版.md', format: 'Markdown', time: '2026-05-31 15:40', size: '486 KB', status: '完成' },
+  { id: 'EXP-003', fileName: '支付渠道路由策略_cases.json', format: 'JSON', time: '2026-05-30 11:04', size: '918 KB', status: '完成' },
+  { id: 'EXP-004', fileName: '开放API鉴权升级_交付报告.pdf', format: 'PDF', time: '2026-05-28 16:02', size: '5.8 MB', status: '处理中' },
+];
+
+export const diffSummary = [
+  { label: '新增用例', value: '28 条', tone: 'text-emerald-600 bg-emerald-50' },
+  { label: '删除用例', value: '6 条', tone: 'text-rose-600 bg-rose-50' },
+  { label: '变更模块', value: '3 个', tone: 'text-blue-600 bg-blue-50' },
+];
+
+export const timelineIcon = GitCompareArrows;

--- a/src/pages/ai-workbench/history-export/types.ts
+++ b/src/pages/ai-workbench/history-export/types.ts
@@ -15,6 +15,10 @@ export interface HistoryRecord {
   owner: string;
   duration: string;
   coverage: string;
+  requirement?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  syncMode?: string;
 }
 
 export interface VersionRecord {

--- a/src/pages/ai-workbench/history-export/types.ts
+++ b/src/pages/ai-workbench/history-export/types.ts
@@ -1,0 +1,52 @@
+import type { LucideIcon } from 'lucide-react';
+
+export type HistoryStatus = 'success' | 'processing' | 'failed';
+export type WorkspaceTab = 'history' | 'versions' | 'exports';
+export type ExportFormat = 'Excel' | 'Markdown' | 'JSON' | 'PDF';
+
+export interface HistoryRecord {
+  id: string;
+  time: string;
+  projectName: string;
+  requirementName: string;
+  generatedContent: string;
+  caseCount: number;
+  status: HistoryStatus;
+  owner: string;
+  duration: string;
+  coverage: string;
+}
+
+export interface VersionRecord {
+  id: string;
+  version: string;
+  title: string;
+  time: string;
+  author: string;
+  summary: string;
+  isCurrent: boolean;
+}
+
+export interface ExportFormatOption {
+  format: ExportFormat;
+  title: string;
+  description: string;
+  icon: LucideIcon;
+}
+
+export interface RecentExport {
+  id: string;
+  fileName: string;
+  format: ExportFormat;
+  time: string;
+  size: string;
+  status: '完成' | '处理中';
+}
+
+export interface StatItem {
+  id: string;
+  label: string;
+  value: string;
+  trend: string;
+  icon: LucideIcon;
+}


### PR DESCRIPTION
### Motivation
- Implement a full SaaS-style “历史记录与导出” workspace to replace the placeholder and provide users with history, versioning and export workflows.  
- Split the page into focused, typed React + TypeScript components to match the project UI and reuse shared layout pieces.  
- Provide deterministic mock data and interactions so the page can be reviewed without backend integration.

### Description
- Replaced the placeholder route handler with the new workspace page and mounted it at the existing AI history path (`/ai-workbench/history-export`).
- Added a component set under `src/pages/ai-workbench/history-export/components/` including `Layout`, `Header`, `Sidebar`, `StatCard`, `HistoryTable`, `VersionComparePanel`, `ExportCenter`, `RecentExportList`, `SyncPanel`, `StatusTag`, `Pagination`, `DetailDrawer`, and `VersionDiffModal` to implement the UI and interactions.
- Added typed mocks and supporting types in `src/pages/ai-workbench/history-export/mock.ts` and `types.ts` with 8 history records, 3 version records, 4 export formats, 4 recent exports, and 4 stat cards; wired export, sync, restore and diff actions to show toasts/confirmations and a 1s simulated sync loading state.
- Implemented visuals and UX per design: page title and breadcrumb, tabs (生成历史 / 版本记录 / 导出中心), status color tags (green/orange/red), pagination UI (total 248, pages 1–5 ... 25, 10 per page and jump input), version timeline with current V1.2 highlighted, right-side detail drawer and version-diff modal, and export buttons that trigger user-facing messages.

### Testing
- Ran TypeScript check: `npx tsc --noEmit -p tsconfig.json`; check was attempted but type resolution for runtime dependencies failed in the current environment (missing/resolvable type declarations for packages such as `react`, `wouter`, `lucide-react`, etc.), so the type-check step could not complete successfully here.
- Attempted build: `npm run build`; the build attempted but failed in this sandbox because the `vite` binary and other node modules were not available in PATH in the current execution environment, so a full production build could not be produced here.
- No unit tests were executed as part of this change in this environment due to dependency installation/build restrictions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f195170b48332b8e20222bfdf5416)