### PR TITLE
Preserve AI workbench generation while streaming

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/NotFound";
-import { Route, Switch, Redirect, useLocation } from "wouter";
+import { Route, Switch, Redirect, Router as WouterRouter, useLocation } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { Layout } from "./components/Layout";
@@ -32,7 +32,7 @@ import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
 import { User } from "lucide-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 const AI_WORKBENCH_CASE_GENERATION_ROUTE = "/ai-workbench/case-generation";
 
@@ -90,19 +90,30 @@ function ProtectedLayout({ children }: { children: ReactNode }) {
  * AI case generation keep-alive layer:
  * - /ai-workbench/case-generation is rendered outside the Switch so route changes do not unmount AICases.
  * - While generation is running, navigating away hides this tree instead of aborting its stream controller.
+ * - Hidden generation keeps the last AI workbench URL in a nested router so AICases does not
+ *   re-read unrelated page query strings and switch docRef to the default workspace mid-stream.
  * - Direct visits still mount immediately and render as the active page.
  */
 function KeepAliveAiWorkbenchCaseGeneration() {
-  const [location] = useLocation();
+  const [location, setLocation] = useLocation();
   const { isGenerating } = useAiGeneration();
   const isCurrentRoute = isAiWorkbenchCaseGenerationRoute(location);
   const [hasVisited, setHasVisited] = useState(() => isCurrentRoute);
+  const [keptAliveLocation, setKeptAliveLocation] = useState(() =>
+    isCurrentRoute ? location : AI_WORKBENCH_CASE_GENERATION_ROUTE
+  );
 
   useEffect(() => {
-    if (isCurrentRoute && !hasVisited) {
+    if (isCurrentRoute) {
       setHasVisited(true);
+      setKeptAliveLocation(location);
     }
-  }, [hasVisited, isCurrentRoute]);
+  }, [isCurrentRoute, location]);
+
+  const useKeptAliveLocation = useCallback(() => [keptAliveLocation, setLocation] as const, [
+    keptAliveLocation,
+    setLocation,
+  ]);
 
   if (!hasVisited && !isGenerating) {
     return null;
@@ -110,9 +121,11 @@ function KeepAliveAiWorkbenchCaseGeneration() {
 
   return (
     <div className={isCurrentRoute ? "fixed inset-0 z-10" : "hidden"}>
-      <ProtectedLayout>
-        <AiWorkbenchCaseGeneration />
-      </ProtectedLayout>
+      <WouterRouter hook={useKeptAliveLocation}>
+        <ProtectedLayout>
+          <AiWorkbenchCaseGeneration />
+        </ProtectedLayout>
+      </WouterRouter>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,14 @@
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/NotFound";
-import { Route, Switch, Redirect } from "wouter";
+import { Route, Switch, Redirect, useLocation } from "wouter";
 import ErrorBoundary from "./components/ErrorBoundary";
 import ProtectedRoute from "./components/ProtectedRoute";
 import { Layout } from "./components/Layout";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { AuthProvider } from "./contexts/AuthContext";
 import { NavCollapseProvider } from "./contexts/NavCollapseContext";
-import { AiGenerationProvider } from "./contexts/AiGenerationContext";
+import { AiGenerationProvider, useAiGeneration } from "./contexts/AiGenerationContext";
 import Home from "./pages/Home";
 import Landing from "./pages/Landing";
 import Login from "./pages/Login";
@@ -32,7 +32,16 @@ import ReportDetail from "./pages/reports/ReportDetail";
 import SystemSettings from "./pages/settings/SystemSettings";
 import { User } from "lucide-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+
+const AI_WORKBENCH_CASE_GENERATION_ROUTE = "/ai-workbench/case-generation";
+
+function isAiWorkbenchCaseGenerationRoute(location: string): boolean {
+  return (
+    location === AI_WORKBENCH_CASE_GENERATION_ROUTE ||
+    location.startsWith(`${AI_WORKBENCH_CASE_GENERATION_ROUTE}?`)
+  );
+}
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -74,6 +83,37 @@ function ProtectedLayout({ children }: { children: ReactNode }) {
     <ProtectedRoute>
       <Layout>{children}</Layout>
     </ProtectedRoute>
+  );
+}
+
+/**
+ * AI case generation keep-alive layer:
+ * - /ai-workbench/case-generation is rendered outside the Switch so route changes do not unmount AICases.
+ * - While generation is running, navigating away hides this tree instead of aborting its stream controller.
+ * - Direct visits still mount immediately and render as the active page.
+ */
+function KeepAliveAiWorkbenchCaseGeneration() {
+  const [location] = useLocation();
+  const { isGenerating } = useAiGeneration();
+  const isCurrentRoute = isAiWorkbenchCaseGenerationRoute(location);
+  const [hasVisited, setHasVisited] = useState(() => isCurrentRoute);
+
+  useEffect(() => {
+    if (isCurrentRoute && !hasVisited) {
+      setHasVisited(true);
+    }
+  }, [hasVisited, isCurrentRoute]);
+
+  if (!hasVisited && !isGenerating) {
+    return null;
+  }
+
+  return (
+    <div className={isCurrentRoute ? "fixed inset-0 z-10" : "hidden"}>
+      <ProtectedLayout>
+        <AiWorkbenchCaseGeneration />
+      </ProtectedLayout>
+    </div>
   );
 }
 
@@ -146,10 +186,9 @@ function Router() {
             <AiWorkbenchRequirementAnalysis />
           </ProtectedLayout>
         </Route>
+        {/* Rendered by KeepAliveAiWorkbenchCaseGeneration outside Switch to avoid aborting active streams. */}
         <Route path="/ai-workbench/case-generation">
-          <ProtectedLayout>
-            <AiWorkbenchCaseGeneration />
-          </ProtectedLayout>
+          {null}
         </Route>
         <Route path="/ai-workbench/quality-coverage">
           <ProtectedLayout>
@@ -216,6 +255,7 @@ function Router() {
         <Route component={NotFound} />
       </Switch>
 
+      <KeepAliveAiWorkbenchCaseGeneration />
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where navigating away from `/ai-workbench/case-generation` unmounted the generator and aborted the streaming generation flow, losing background progress and cross-page notifications. 
- Restore the previous keep-alive behavior so generation continues and UI state is preserved while `isGenerating` is true.

### Description
- Updated `src/App.tsx` to import `useLocation` and `useAiGeneration`, and added `useEffect`/`useState` usage for the keep-alive logic.  
- Added `AI_WORKBENCH_CASE_GENERATION_ROUTE` and `isAiWorkbenchCaseGenerationRoute` helper to detect direct visits and query-string variants.  
- Introduced `KeepAliveAiWorkbenchCaseGeneration` which mounts `AiWorkbenchCaseGeneration` outside the `Switch` and keeps it mounted after a visit or while `isGenerating` is true, rendering it visible only when the route is active and otherwise keeping it hidden to avoid unmount.  
- Replaced the in-Switch `/ai-workbench/case-generation` route with a placeholder that returns `null`, and render the keep-alive component after the `Switch` so it is the single owner of the generation UI tree.

### Testing
- Ran `git diff --check` which passed with no whitespace/diff errors.  
- Attempted `npx tsc --noEmit -p tsconfig.json` but it could not complete in this environment because project dependencies and type packages are not installed, producing missing-module/type errors for React, Wouter, TanStack Query, etc.  
- Attempted `npm ci` but it failed because `package-lock.json` is out of sync with `package.json` (missing `esbuild` entry), so a full install and unit test run could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f198aa6048332a2821f580c7005be)