### PR TITLE
Fix uploaded requirement parsing to use file contents

### DIFF
--- a/src/components/__tests__/RequirementInputUtils.test.tsx
+++ b/src/components/__tests__/RequirementInputUtils.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cleanRequirementText, defaultCleanRules, formatFileSize, getFileType } from '@/lib/requirementInput';
+import { buildUploadedFileContent, cleanRequirementText, defaultCleanRules, formatFileSize, getFileType } from '@/lib/requirementInput';
 
 describe('cleanRequirementText', () => {
   it('removes empty lines and extra spaces while preserving heading levels', () => {
@@ -43,5 +43,28 @@ describe('requirement input file utilities', () => {
     expect(formatFileSize(512)).toBe('512 B');
     expect(formatFileSize(1024)).toBe('1.0 KB');
     expect(formatFileSize(1024 * 1024)).toBe('1.00 MB');
+  });
+
+  it('combines uploaded file contents instead of using simulated requirements', () => {
+    expect(
+      buildUploadedFileContent([
+        {
+          id: 'file-1',
+          name: 'checkout.md',
+          size: '1.0 KB',
+          status: '等待解析',
+          type: 'markdown',
+          content: '用户可以提交订单。',
+        },
+        {
+          id: 'file-2',
+          name: 'empty.md',
+          size: '0 B',
+          status: '上传失败',
+          type: 'markdown',
+          content: '',
+        },
+      ])
+    ).toBe('# checkout.md\n用户可以提交订单。');
   });
 });

--- a/src/lib/requirementInput.ts
+++ b/src/lib/requirementInput.ts
@@ -25,6 +25,8 @@ export interface UploadedFileItem {
   size: string;
   status: UploadedFileStatus;
   type: UploadedFileType;
+  content: string;
+  errorMessage?: string;
 }
 
 export interface CleanRules {
@@ -104,6 +106,7 @@ export const mockUploadedFiles: UploadedFileItem[] = [
     size: '1.24 MB',
     status: '上传成功',
     type: 'word',
+    content: sampleRequirementText,
   },
   {
     id: 'mock-pdf-1',
@@ -111,6 +114,7 @@ export const mockUploadedFiles: UploadedFileItem[] = [
     size: '856 KB',
     status: '上传成功',
     type: 'pdf',
+    content: sampleRequirementText,
   },
 ];
 
@@ -171,6 +175,13 @@ function mergeAbnormalLineBreaks(input: string, rules: CleanRules): string {
   }
 
   return merged.join('\n');
+}
+
+export function buildUploadedFileContent(files: UploadedFileItem[]): string {
+  return files
+    .filter((file) => file.status !== '上传失败' && file.content.trim().length > 0)
+    .map((file) => `# ${file.name}\n${file.content.trim()}`)
+    .join('\n\n');
 }
 
 export function cleanRequirementText(input: string, rules: CleanRules): string {

--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -11,6 +11,7 @@ import RequirementUploadPanel from '@/pages/cases/components/RequirementUploadPa
 import UploadedFileList from '@/pages/cases/components/UploadedFileList';
 import type { CleanRules, GenerateTarget, RequirementInputMode, RequirementInputState, RequirementType, UploadedFileItem } from '@/lib/requirementInput';
 import {
+  buildUploadedFileContent,
   cleanRequirementText,
   defaultCleanRules,
   initialRequirementInputState,
@@ -19,20 +20,6 @@ import {
 } from '@/lib/requirementInput';
 
 const parseStepDelayMs = 650;
-const simulatedDocumentContent = `1. 项目概述
-本需求来自已上传需求文档，描述电商平台会员中心能力升级。
-
-2. 功能需求
-2.1 会员注册
-- 用户可通过手机号、邮箱进行注册。
-- 注册时需填写验证码，验证码有效期为 5 分钟。
-用户点击注册后，
-系统需要校验验证码与账号唯一性。
-
-2.2 登录与登出
-- 支持账号密码登录。
-- 支持短信验证码登录。
-- 用户可主动退出登录。`;
 
 function buildInitialState(): RequirementInputState {
   const draft = loadDraftFromStorage();
@@ -73,7 +60,19 @@ export default function RequirementInputParsePage(): JSX.Element {
   }, []);
 
   const handleFilesAdd = useCallback((files: UploadedFileItem[]): void => {
+    if (files.length === 0) {
+      toast.error('文件读取失败，请重新上传。');
+      return;
+    }
+
     setState((current) => ({ ...current, uploadedFiles: [...files, ...current.uploadedFiles] }));
+
+    const failedCount = files.filter((file) => file.status === '上传失败').length;
+    if (failedCount > 0) {
+      toast.warning(`已添加 ${files.length} 个文件，其中 ${failedCount} 个文件读取失败`);
+      return;
+    }
+
     toast.success(`已添加 ${files.length} 个文件，等待解析`);
   }, []);
 
@@ -121,8 +120,13 @@ export default function RequirementInputParsePage(): JSX.Element {
       return;
     }
 
+    const rawContent = state.requirementText.trim().length > 0 ? state.requirementText : buildUploadedFileContent(state.uploadedFiles);
+    if (rawContent.trim().length === 0) {
+      toast.error('未能读取到有效的上传文件内容，请重新上传或粘贴需求文本。');
+      return;
+    }
+
     clearTimers();
-    const rawContent = state.requirementText.trim().length > 0 ? state.requirementText : simulatedDocumentContent;
     setState((current) => ({
       ...current,
       rawContent,
@@ -153,7 +157,7 @@ export default function RequirementInputParsePage(): JSX.Element {
       toast.success('需求内容解析与清洗完成');
     }, parseStepDelayMs * 4);
     timersRef.current.push(finishTimer);
-  }, [canStartParse, clearTimers, state.requirementText]);
+  }, [canStartParse, clearTimers, state.requirementText, state.uploadedFiles]);
 
   return (
     <div className="min-h-full bg-slate-50 px-6 py-6 text-slate-900 lg:px-8">

--- a/src/pages/cases/components/RequirementUploadPanel.tsx
+++ b/src/pages/cases/components/RequirementUploadPanel.tsx
@@ -28,20 +28,58 @@ export default function RequirementUploadPanel({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
-  const createFileItems = (files: FileList): UploadedFileItem[] => Array.from(files).map((file) => ({
-    id: `${file.name}-${file.size}-${file.lastModified}`,
-    name: file.name,
-    size: formatFileSize(file.size),
-    status: file.size > 50 * 1024 * 1024 ? '上传失败' : '等待解析',
-    type: getFileType(file.name),
-  }));
+  const createFileItems = async (files: FileList): Promise<UploadedFileItem[]> => {
+    const fileItems = Array.from(files).map(async (file): Promise<UploadedFileItem> => {
+      const fileBase = {
+        id: `${file.name}-${file.size}-${file.lastModified}`,
+        name: file.name,
+        size: formatFileSize(file.size),
+        type: getFileType(file.name),
+      };
+
+      if (file.size > 50 * 1024 * 1024) {
+        return {
+          ...fileBase,
+          status: '上传失败',
+          content: '',
+          errorMessage: '文件超过 50MB，未读取内容。',
+        };
+      }
+
+      try {
+        const content = await file.text();
+        return {
+          ...fileBase,
+          status: content.trim().length > 0 ? '等待解析' : '上传失败',
+          content,
+          errorMessage: content.trim().length > 0 ? undefined : '文件内容为空，无法解析。',
+        };
+      } catch {
+        return {
+          ...fileBase,
+          status: '上传失败',
+          content: '',
+          errorMessage: '读取文件内容失败，请重新上传。',
+        };
+      }
+    });
+
+    return Promise.all(fileItems);
+  };
 
   const handleFiles = (files: FileList | null): void => {
     if (!files || files.length === 0) {
       return;
     }
 
-    onFilesAdd(createFileItems(files));
+    void (async (): Promise<void> => {
+      try {
+        const fileItems = await createFileItems(files);
+        onFilesAdd(fileItems);
+      } catch {
+        onFilesAdd([]);
+      }
+    })();
   };
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {


### PR DESCRIPTION
### Motivation

- Uploaded-only parsing used a hard-coded simulated document instead of the actual uploaded payload, causing incorrect parsed requirements for users who only upload files.
- The upload panel stored only metadata (name/size/status/type) so downstream parsing couldn't access file text content.

### Description

- Add `content` and optional `errorMessage` to `UploadedFileItem` and populate `mockUploadedFiles` with `sampleRequirementText` for consistent mocked behavior in `src/lib/requirementInput.ts`.
- Implement `buildUploadedFileContent(files)` in `src/lib/requirementInput.ts` to aggregate readable uploaded file contents for parsing instead of using the simulated fallback.
- Read file text on upload in `RequirementUploadPanel` by converting `createFileItems` to an async reader that sets status/content/errorMessage and return the enriched items to the page component.
- Replace the simulated-document fallback in `RequirementInputParsePage` with `buildUploadedFileContent(state.uploadedFiles)` and add validations/toasts for empty or failed uploads so parsing only proceeds with real file content.

### Testing

- Added a unit test `src/components/__tests__/RequirementInputUtils.test.tsx` that verifies `buildUploadedFileContent` aggregates uploaded file contents and ignores failed/empty uploads, and this test file was added to the test suite.
- Ran a focused TypeScript check on the changed module with `tsc --ignoreConfig --noEmit --target es2020 --module esnext --lib dom,es2020 --skipLibCheck src/lib/requirementInput.ts` which completed successfully.
- Running the added Vitest unit (`npx vitest run src/components/__tests__/RequirementInputUtils.test.tsx`) could not be executed in this environment because dependencies are not installed and npm registry access returned 403, preventing full test execution and a full project type-check that requires installed types.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f1cf07f188332b35174cb670f6859)