### PR TITLE
Restore AI workspace routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,10 +20,10 @@ import Tasks from "./pages/tasks/Tasks";
 import APICases from "./pages/cases/APICases";
 import UICases from "./pages/cases/UICases";
 import PerformanceCases from "./pages/cases/PerformanceCases";
+import AICases from "./pages/cases/AICases";
+import AICaseCreate from "./pages/cases/AICaseCreate";
 import AiWorkbenchOverview from "./pages/ai-workbench/AiWorkbenchOverview";
-import AiWorkbenchRequirementInput from "./pages/ai-workbench/AiWorkbenchRequirementInput";
 import AiWorkbenchRequirementAnalysis from "./pages/ai-workbench/AiWorkbenchRequirementAnalysis";
-import AiWorkbenchCaseGeneration from "./pages/ai-workbench/AiWorkbenchCaseGeneration";
 import AiWorkbenchQualityCoverage from "./pages/ai-workbench/AiWorkbenchQualityCoverage";
 import AiWorkbenchHistoryExport from "./pages/ai-workbench/AiWorkbenchHistoryExport";
 import AiWorkbenchSettings from "./pages/ai-workbench/AiWorkbenchSettings";
@@ -124,7 +124,7 @@ function KeepAliveAiWorkbenchCaseGeneration() {
     <div className={isCurrentRoute ? "fixed inset-0 z-10" : "hidden"}>
       <WouterRouter hook={useKeptAliveLocation}>
         <ProtectedLayout>
-          <AiWorkbenchCaseGeneration />
+          <AICases />
         </ProtectedLayout>
       </WouterRouter>
     </div>
@@ -190,7 +190,7 @@ function Router() {
         </Route>
         <Route path="/ai-workbench/requirement-input">
           <ProtectedLayout>
-            <AiWorkbenchRequirementInput />
+            <AICaseCreate />
           </ProtectedLayout>
         </Route>
         <Route path="/ai-workbench/requirement-analysis">


### PR DESCRIPTION
### Motivation
- Fix two P1 regressions where the AI workbench lost saved workspace resume behavior and the requirement input entry point was replaced by placeholders, preventing users from resuming or creating AI workspaces.

### Description
- Replaced the placeholder generator with the persisted workspace by rendering `AICases` inside the keep-alive layer for `/ai-workbench/case-generation` in `src/App.tsx` so query `docId` resume links load saved workspaces.
- Restored the requirement input entry point by routing `/ai-workbench/requirement-input` to `AICaseCreate` in `src/App.tsx` so users can upload/input requirements and start generation.
- Updated imports in `src/App.tsx` to include `AICases` and `AICaseCreate` and removed the unused placeholder imports.

### Testing
- Ran TypeScript type-check: `npx tsc --noEmit -p tsconfig.json`, which completed successfully.
- Verified the repository compiles after the change (type-check only); no additional automated UI tests were run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218204196c8332b34a8ac25146dfe2)