### PR TITLE
Restrict uploads to Markdown/TXT, add readable-file handling & messages, update mocks and expand sidebar dropdown height

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -305,7 +305,7 @@ function ExpandedNavItem({ item, location, onNavigate, defaultExpanded, badge }:
         {/* Children */}
         <div
           className={`overflow-hidden transition-all duration-200 ease-out ${
-            expanded ? "max-h-48 opacity-100" : "max-h-0 opacity-0"
+            expanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
           }`}
         >
           <div className="ml-3 pl-3 border-l-2 border-slate-100 dark:border-slate-800 space-y-0.5 py-1">

--- a/src/components/__tests__/RequirementInputUtils.test.tsx
+++ b/src/components/__tests__/RequirementInputUtils.test.tsx
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { buildUploadedFileContent, cleanRequirementText, defaultCleanRules, formatFileSize, getFileType } from '@/lib/requirementInput';
+import {
+  buildUploadedFileContent,
+  cleanRequirementText,
+  defaultCleanRules,
+  formatFileSize,
+  getFileType,
+  getReadableUploadErrorMessage,
+  isReadableUploadedFileType,
+} from '@/lib/requirementInput';
 
 describe('cleanRequirementText', () => {
   it('removes empty lines and extra spaces while preserving heading levels', () => {
@@ -45,7 +53,7 @@ describe('requirement input file utilities', () => {
     expect(formatFileSize(1024 * 1024)).toBe('1.00 MB');
   });
 
-  it('combines uploaded file contents instead of using simulated requirements', () => {
+  it('combines uploaded readable text file contents instead of using simulated requirements', () => {
     expect(
       buildUploadedFileContent([
         {
@@ -66,5 +74,26 @@ describe('requirement input file utilities', () => {
         },
       ])
     ).toBe('# checkout.md\n用户可以提交订单。');
+  });
+
+  it('rejects binary document types instead of treating raw bytes as readable content', () => {
+    expect(isReadableUploadedFileType('markdown')).toBe(true);
+    expect(isReadableUploadedFileType('txt')).toBe(true);
+    expect(isReadableUploadedFileType('word')).toBe(false);
+    expect(isReadableUploadedFileType('pdf')).toBe(false);
+    expect(isReadableUploadedFileType('excel')).toBe(false);
+    expect(getReadableUploadErrorMessage('pdf')).toContain('Word/PDF/Excel');
+    expect(
+      buildUploadedFileContent([
+        {
+          id: 'file-1',
+          name: 'requirements.pdf',
+          size: '1.0 MB',
+          status: '等待解析',
+          type: 'pdf',
+          content: '%PDF-1.7 raw internals',
+        },
+      ])
+    ).toBe('');
   });
 });

--- a/src/lib/requirementInput.ts
+++ b/src/lib/requirementInput.ts
@@ -16,6 +16,7 @@ export type GenerateTarget =
 
 export type UploadedFileStatus = '上传成功' | '上传失败' | '等待解析';
 export type UploadedFileType = 'word' | 'pdf' | 'markdown' | 'excel' | 'txt' | 'unknown';
+export type ReadableUploadedFileType = Extract<UploadedFileType, 'markdown' | 'txt'>;
 export type RequirementInputMode = 'upload' | 'text';
 export type ParseStatus = 'idle' | 'parsing' | 'success' | 'error';
 
@@ -101,19 +102,19 @@ export const sampleRequirementText = `1. 项目概述
 
 export const mockUploadedFiles: UploadedFileItem[] = [
   {
-    id: 'mock-docx-1',
-    name: '电商平台需求规格说明书_v2.1.docx',
-    size: '1.24 MB',
+    id: 'mock-md-1',
+    name: '电商平台需求规格说明书_v2.1.md',
+    size: '24 KB',
     status: '上传成功',
-    type: 'word',
+    type: 'markdown',
     content: sampleRequirementText,
   },
   {
-    id: 'mock-pdf-1',
-    name: '会员中心功能需求补充说明.pdf',
-    size: '856 KB',
+    id: 'mock-txt-1',
+    name: '会员中心功能需求补充说明.txt',
+    size: '12 KB',
     status: '上传成功',
-    type: 'pdf',
+    type: 'txt',
     content: sampleRequirementText,
   },
 ];
@@ -177,9 +178,23 @@ function mergeAbnormalLineBreaks(input: string, rules: CleanRules): string {
   return merged.join('\n');
 }
 
+export function isReadableUploadedFileType(type: UploadedFileType): type is ReadableUploadedFileType {
+  return type === 'markdown' || type === 'txt';
+}
+
+export function getReadableUploadErrorMessage(type: UploadedFileType): string {
+  if (type === 'word' || type === 'pdf' || type === 'excel') {
+    return '当前仅支持读取 Markdown/TXT 文本内容，Word/PDF/Excel 文件需要先转换为可读文本后再上传。';
+  }
+
+  return '不支持的文件格式，请上传 Markdown 或 TXT 文本文件。';
+}
+
 export function buildUploadedFileContent(files: UploadedFileItem[]): string {
   return files
-    .filter((file) => file.status !== '上传失败' && file.content.trim().length > 0)
+    .filter(
+      (file) => file.status !== '上传失败' && isReadableUploadedFileType(file.type) && file.content.trim().length > 0
+    )
     .map((file) => `# ${file.name}\n${file.content.trim()}`)
     .join('\n\n');
 }

--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -67,9 +67,15 @@ export default function RequirementInputParsePage(): JSX.Element {
 
     setState((current) => ({ ...current, uploadedFiles: [...files, ...current.uploadedFiles] }));
 
-    const failedCount = files.filter((file) => file.status === '上传失败').length;
-    if (failedCount > 0) {
-      toast.warning(`已添加 ${files.length} 个文件，其中 ${failedCount} 个文件读取失败`);
+    const failedFiles = files.filter((file) => file.status === '上传失败');
+    if (failedFiles.length > 0) {
+      const failureDescription = Array.from(
+        new Set(failedFiles.map((file) => file.errorMessage).filter((message): message is string => Boolean(message)))
+      ).join('；');
+
+      toast.warning(`已添加 ${files.length} 个文件，其中 ${failedFiles.length} 个文件读取失败`, {
+        description: failureDescription || '请查看上传列表中的失败原因。',
+      });
       return;
     }
 

--- a/src/pages/cases/components/RequirementUploadPanel.tsx
+++ b/src/pages/cases/components/RequirementUploadPanel.tsx
@@ -1,9 +1,9 @@
 import { ChangeEvent, DragEvent, useRef, useState } from 'react';
-import { FileSpreadsheet, FileText, FileType2, UploadCloud } from 'lucide-react';
+import { FileText, FileType2, UploadCloud } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import type { RequirementInputMode, UploadedFileItem } from '@/lib/requirementInput';
-import { formatFileSize, getFileType } from '@/lib/requirementInput';
+import { formatFileSize, getFileType, getReadableUploadErrorMessage, isReadableUploadedFileType } from '@/lib/requirementInput';
 
 interface RequirementUploadPanelProps {
   inputMode: RequirementInputMode;
@@ -11,13 +11,11 @@ interface RequirementUploadPanelProps {
   onFilesAdd: (files: UploadedFileItem[]) => void;
 }
 
-const acceptedFileExtensions = '.doc,.docx,.pdf,.md,.txt,.xls,.xlsx';
+const acceptedFileExtensions = '.md,.txt';
 
 const formatTags = [
-  { label: 'Word', suffix: '.docx', icon: FileText, className: 'bg-blue-50 text-blue-700 border-blue-100' },
-  { label: 'PDF', suffix: '.pdf', icon: FileType2, className: 'bg-red-50 text-red-700 border-red-100' },
   { label: 'Markdown', suffix: '.md', icon: FileText, className: 'bg-slate-50 text-slate-700 border-slate-200' },
-  { label: 'Excel', suffix: '.xlsx', icon: FileSpreadsheet, className: 'bg-emerald-50 text-emerald-700 border-emerald-100' },
+  { label: 'TXT', suffix: '.txt', icon: FileType2, className: 'bg-blue-50 text-blue-700 border-blue-100' },
 ] as const;
 
 export default function RequirementUploadPanel({
@@ -36,6 +34,15 @@ export default function RequirementUploadPanel({
         size: formatFileSize(file.size),
         type: getFileType(file.name),
       };
+
+      if (!isReadableUploadedFileType(fileBase.type)) {
+        return {
+          ...fileBase,
+          status: '上传失败',
+          content: '',
+          errorMessage: getReadableUploadErrorMessage(fileBase.type),
+        };
+      }
 
       if (file.size > 50 * 1024 * 1024) {
         return {
@@ -59,7 +66,7 @@ export default function RequirementUploadPanel({
           ...fileBase,
           status: '上传失败',
           content: '',
-          errorMessage: '读取文件内容失败，请重新上传。',
+          errorMessage: '读取文本内容失败，请重新上传。',
         };
       }
     });
@@ -167,7 +174,7 @@ export default function RequirementUploadPanel({
               点击上传
             </Button>
           </p>
-          <p className="mt-2 text-sm text-slate-500">支持 Word、PDF、Markdown、Excel 格式，单个文件不超过 50MB</p>
+          <p className="mt-2 text-sm text-slate-500">支持 Markdown、TXT 文本格式，单个文件不超过 50MB；Word、PDF、Excel 请先转换为可读文本后上传</p>
           <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
             {formatTags.map((tag) => {
               const Icon = tag.icon;

--- a/src/pages/cases/components/UploadedFileList.tsx
+++ b/src/pages/cases/components/UploadedFileList.tsx
@@ -53,6 +53,11 @@ export default function UploadedFileList({ files, onPreview, onDelete }: Uploade
                       {getFileIcon(file.type)}
                       <span className="max-w-[260px] truncate" title={file.name}>{file.name}</span>
                     </div>
+                    {file.errorMessage ? (
+                      <p className="mt-1 max-w-[360px] text-xs leading-5 text-rose-600" title={file.errorMessage}>
+                        {file.errorMessage}
+                      </p>
+                    ) : null}
                   </td>
                   <td className="px-4 py-3 text-slate-600">{file.size}</td>
                   <td className="px-4 py-3">{getStatusBadge(file.status)}</td>


### PR DESCRIPTION
### Motivation
- Prevent treating binary document bytes as readable text by only accepting Markdown/TXT uploads and providing clear error messages for Word/PDF/Excel files.
- Provide a better upload UX by marking unsupported files as failed with explanatory messages and by showing realistic mock uploaded files for text mode.
- Improve sidebar UX by increasing the expanded children container max height so longer lists are fully visible.

### Description
- Added `ReadableUploadedFileType` type and utility `isReadableUploadedFileType` in `src/lib/requirementInput.ts` to detect readable file types and `getReadableUploadErrorMessage` to provide user-facing guidance.
- Updated `buildUploadedFileContent` to only concatenate contents from readable file types (`markdown`/`txt`).
- Replaced binary mock uploads with text-based mocks and adjusted `mockUploadedFiles` entries to use `.md` and `.txt` in `src/lib/requirementInput.ts`.
- Updated `RequirementUploadPanel` to only accept `.md,.txt`, show updated supported formats text, mark non-readable uploads as `上传失败` with an `errorMessage`, and avoid reading non-text files in `createFileItems` in `src/pages/cases/components/RequirementUploadPanel.tsx`.
- Adjusted upload error wording when file text reading fails and simplified accepted extensions and format tags in the upload panel.
- Increased the expanded navigation children container max height from `max-h-48` to `max-h-96` in `src/components/Sidebar.tsx` to allow more space for child items.
- Extended and updated tests in `src/components/__tests__/RequirementInputUtils.test.tsx` to cover readable-file checks, error messages, and build behavior for binary-like inputs.

### Testing
- Ran unit tests with `vitest`, including `RequirementInputUtils.test.tsx`, and all tests passed.
- Verified the modified file acceptance/reading logic via the updated unit tests that assert `isReadableUploadedFileType`, `getReadableUploadErrorMessage`, and `buildUploadedFileContent` behavior (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2181f7c0248332abaa216f4519a551)