### PR TITLE
Fix requirement input route import

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import APICases from "./pages/cases/APICases";
 import UICases from "./pages/cases/UICases";
 import PerformanceCases from "./pages/cases/PerformanceCases";
 import AICases from "./pages/cases/AICases";
-import AICaseCreate from "./pages/cases/AICaseCreate";
+import AiWorkbenchRequirementInput from "./pages/ai-workbench/AiWorkbenchRequirementInput";
 import AiWorkbenchOverview from "./pages/ai-workbench/AiWorkbenchOverview";
 import AiWorkbenchRequirementAnalysis from "./pages/ai-workbench/AiWorkbenchRequirementAnalysis";
 import AiWorkbenchQualityCoverage from "./pages/ai-workbench/AiWorkbenchQualityCoverage";
@@ -193,7 +193,7 @@ function Router() {
         </Route>
         <Route path="/ai-workbench/requirement-input">
           <ProtectedLayout>
-            <AICaseCreate />
+            <AiWorkbenchRequirementInput />
           </ProtectedLayout>
         </Route>
         <Route path="/ai-workbench/requirement-analysis">


### PR DESCRIPTION
### Motivation
- The `/ai-workbench/requirement-input` route was importing `./pages/cases/AICaseCreate`, which does not exist under `src`, causing the route to fail resolving during build.

### Description
- Updated `src/App.tsx` to import `AiWorkbenchRequirementInput` from `./pages/ai-workbench/AiWorkbenchRequirementInput` and render `<AiWorkbenchRequirementInput />` for the `/ai-workbench/requirement-input` route so the route points at the existing wrapper component.

### Testing
- Ran `npx tsc --noEmit -p tsconfig.json` which completed without errors.
- Ran `npm run build` which completed successfully and produced the production build.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218a03623483328123c59d9d1c0688)