### PR TITLE
Refactor AI Workbench routing & workspace query detection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
 const AI_WORKBENCH_CASE_GENERATION_ROUTE = "/ai-workbench/case-generation";
+const AI_WORKBENCH_OVERVIEW_ROUTE = "/ai-workbench/overview";
+const AI_WORKBENCH_HISTORY_EXPORT_ROUTE = "/ai-workbench/history-export";
 
 function isAiWorkbenchCaseGenerationRoute(location: string): boolean {
   return (
@@ -181,7 +183,7 @@ function Router() {
           {null}
         </Route>
         <Route path="/ai-workbench/records">
-          <Redirect to="/ai-workbench/history-export" />
+          <Redirect to={AI_WORKBENCH_HISTORY_EXPORT_ROUTE} />
         </Route>
         <Route path="/ai-workbench/overview">
           <ProtectedLayout>
@@ -213,14 +215,15 @@ function Router() {
             <AiWorkbenchSettings />
           </ProtectedLayout>
         </Route>
+        {/* Legacy AI case URLs now redirect to AI Workbench routes instead of importing the retired create page. */}
         <Route path="/cases/ai-create">
-          <Redirect to="/ai-workbench/overview" />
+          <Redirect to={AI_WORKBENCH_OVERVIEW_ROUTE} />
         </Route>
         <Route path="/cases/ai-history">
-          <Redirect to="/ai-workbench/history-export" />
+          <Redirect to={AI_WORKBENCH_HISTORY_EXPORT_ROUTE} />
         </Route>
         <Route path="/cases/ai">
-          <Redirect to="/ai-workbench/overview" />
+          <Redirect to={AI_WORKBENCH_OVERVIEW_ROUTE} />
         </Route>
 
         <Route path="/tasks">

--- a/src/pages/ai-workbench/AiWorkbenchCaseGeneration.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchCaseGeneration.tsx
@@ -46,6 +46,7 @@ const DEFAULT_CASE_COUNT_PER_POINT = 2;
 const GENERATED_CASE_TOTAL = TEST_POINT_COUNT * DEFAULT_CASE_COUNT_PER_POINT;
 const CASE_TEMPLATES = ['标准功能用例模板（推荐）', '接口测试用例模板', '并发测试用例模板', '简版测试点模板'];
 const GRANULARITIES = ['简单版', '标准版', '详细版'] as const;
+const WORKSPACE_QUERY_PARAMS = ['docId', 'autoGenerate', 'initName', 'initReq'] as const;
 type Granularity = (typeof GRANULARITIES)[number];
 type AutomationFilter = '全部' | '是' | '否';
 type SelectAllState = boolean | 'indeterminate';
@@ -166,7 +167,7 @@ function toFormState(testCase: GeneratedTestCase): CaseFormState {
 function hasWorkspaceParams(search: string): boolean {
   const query = search.startsWith('?') ? search.slice(1) : search;
   const params = new URLSearchParams(query);
-  return Boolean(params.get('docId') || params.get('autoGenerate') || params.get('initName') || params.get('initReq'));
+  return WORKSPACE_QUERY_PARAMS.some((paramName) => params.has(paramName));
 }
 
 function exportCases(cases: GeneratedTestCase[]) {
@@ -716,6 +717,7 @@ function StandaloneAiWorkbenchCaseGeneration(): JSX.Element {
 export default function AiWorkbenchCaseGeneration(): JSX.Element {
   const search = useSearch();
 
+  // wouter's useLocation only exposes the pathname, so workspace routing must read location.search.
   if (hasWorkspaceParams(search)) {
     return <AICases />;
   }


### PR DESCRIPTION
### Motivation
- Centralize AI Workbench route strings and replace duplicated literals to make redirects easier to maintain.
- Detect workspace-specific query parameters reliably to decide whether to render the legacy AI cases import path or the standalone Workbench UI.

### Description
- Introduced `AI_WORKBENCH_OVERVIEW_ROUTE` and `AI_WORKBENCH_HISTORY_EXPORT_ROUTE` constants and replaced inline route strings in redirects with these constants in `src/App.tsx`.
- Added a `WORKSPACE_QUERY_PARAMS` tuple and refactored `hasWorkspaceParams` in `src/pages/ai-workbench/AiWorkbenchCaseGeneration.tsx` to use `URLSearchParams.has` for more robust detection of workspace parameters.
- Added a comment in `AiWorkbenchCaseGeneration` noting that `useLocation`/`useSearch` behavior requires reading `location.search` for workspace routing, and return `AICases` when workspace params are present.
- Left `/ai-workbench/case-generation` rendering placeholder intact and added a comment in `App.tsx` clarifying legacy AI case URL redirects to Workbench routes.

### Testing
- Ran type checks and the project build with `yarn build` which completed successfully.
- Ran the test suite with `yarn test` and all tests passed.
- Ran `yarn lint` to verify formatting and lint rules, which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21898252988332af9cdf95ffbb24b2)