### PR TITLE
优化 AI Workbench 首页顶部 Header 布局

### DIFF
--- a/src/pages/ai-workbench/Overview.tsx
+++ b/src/pages/ai-workbench/Overview.tsx
@@ -50,16 +50,18 @@ export default function Overview() {
   return (
     <div className="max-w-full overflow-hidden p-6">
       <div className="space-y-6">
-        <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <section className="flex min-h-[120px] flex-col items-start justify-between gap-6 rounded-xl border border-slate-200 bg-white px-8 py-6 shadow-[0_4px_16px_rgba(15,23,42,0.04)] dark:border-slate-800 dark:bg-slate-950/60 md:flex-row md:items-center">
           <div>
-            <Badge variant="secondary" className="mb-3">AI Workbench</Badge>
-            <h1 className="text-3xl font-bold tracking-tight text-slate-950 dark:text-white">AI 测试用例生成工作台</h1>
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">从需求输入、测试点确认到用例生成与导出的一站式效率看板。</p>
+            <div className="mb-1.5 text-[13px] font-semibold leading-5 text-blue-600">AI Workbench</div>
+            <h1 className="m-0 text-[26px] font-bold leading-[34px] text-slate-950 dark:text-white">AI 测试用例生成工作台</h1>
+            <p className="mt-2 text-sm leading-[22px] text-slate-500 dark:text-slate-400">从需求输入、测试点确认到用例生成与导出的一站式效率看板。</p>
           </div>
-          <Button className="gap-2"><Rocket className="h-4 w-4" />快速新建需求</Button>
-        </div>
+          <div className="w-full md:w-auto">
+            <Button className="h-10 w-full gap-2 rounded-lg bg-green-600 px-5 font-medium text-white hover:bg-green-700 md:w-auto"><Rocket className="h-4 w-4" />快速新建需求</Button>
+          </div>
+        </section>
 
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <section className="!mt-5 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
           {stats.map((item) => {
             const Icon = item.icon;
             return (
@@ -75,7 +77,7 @@ export default function Overview() {
               </Card>
             );
           })}
-        </div>
+        </section>
 
         <div className="grid gap-6 xl:grid-cols-[1.2fr_0.8fr]">
           <Card>


### PR DESCRIPTION
### Motivation
- 解决顶部区域高度过大、标题层级不清晰、右侧按钮位置孤立以及 Header 与统计卡片间距过大等视觉和布局问题，使首屏信息更紧凑且与系统风格一致。

### Description
- 将顶部区域改为左右 `flex` 布局并包装为卡片式 Header，调整为 `min-h-[120px]`、`px-8 py-6`、细边框与轻阴影，文件：`src/pages/ai-workbench/Overview.tsx`。
- 优化文字层级：把 `AI Workbench` 改为小号蓝色标签，主标题使用 `26px/34px`，副标题使用更浅的说明文字以增强层级感（对应样式使用内联 Tailwind 类）。
- 将“快速新建需求”按钮移至右侧操作区域并改为绿色 CTA，移动端支持全宽，保证与标题自然对齐并居中垂直对齐。
- 缩小 Header 与统计卡片间距（改为紧随的 `section` 并使用 `!mt-5`），且未修改下方统计卡片的数据结构或其他业务模块。

### Testing
- 运行 `npx tsc --noEmit -p tsconfig.json` 检查类型，结果通过（无阻断性错误）。
- 运行 `npm run build`（`vite build`）进行生产构建，构建成功且未引入新的错误或警告阻断构建。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a218fb874dc8332abf1fd8a95c856ac)