### PR TITLE
Prevent premature scheduled execution aborts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ __pycache__/
 .catpaw/
 node_modules
 .playwright-mcp/*
+.codegraph/
 
 # 规则忽略文件
 CLAUDE.md

--- a/server/config/monitoring.ts
+++ b/server/config/monitoring.ts
@@ -44,6 +44,36 @@ export const HYBRID_SYNC_CONFIG = {
  * Execution Monitor Service Configuration
  * Controls background monitoring for stuck executions
  */
+const DEFAULT_JENKINS_QUEUE_POLL_TIMEOUT_MS = 30 * 60 * 1000;
+
+export const JENKINS_QUEUE_CONFIG = {
+  /**
+   * How long to wait for a queued Jenkins item to receive a build number.
+   * Default is 30 minutes so scheduled batches are not aborted during executor congestion.
+   */
+  POLL_TIMEOUT_MS: parseInt(
+    process.env.JENKINS_QUEUE_POLL_TIMEOUT_MS || String(DEFAULT_JENKINS_QUEUE_POLL_TIMEOUT_MS),
+    10,
+  ),
+} as const;
+
+const MIN_EARLY_STUCK_THRESHOLD_SECONDS = Math.ceil(JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS / 1000) + 60;
+
+const DEFAULT_PENDING_NO_BUILD_CLEANUP_MINUTES = Math.max(
+  60,
+  Math.ceil(JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS / 60000) + 5,
+);
+
+const configuredEarlyStuckThresholdSeconds = parseInt(
+  process.env.EARLY_STUCK_THRESHOLD_SECONDS || String(MIN_EARLY_STUCK_THRESHOLD_SECONDS),
+  10,
+);
+
+const configuredPendingNoBuildCleanupMinutes = parseInt(
+  process.env.EXECUTION_PENDING_NO_BUILD_CLEANUP_MINUTES || String(DEFAULT_PENDING_NO_BUILD_CLEANUP_MINUTES),
+  10,
+);
+
 export const EXECUTION_MONITOR_CONFIG = {
   /** Monitor cycle interval in milliseconds (default: 20s) */
   CHECK_INTERVAL: parseInt(process.env.EXECUTION_MONITOR_INTERVAL || '20000', 10),
@@ -63,11 +93,26 @@ export const EXECUTION_MONITOR_CONFIG = {
   /** Quick fail threshold in seconds (default: 20s) */
   QUICK_FAIL_THRESHOLD_SECONDS: parseInt(process.env.QUICK_FAIL_THRESHOLD_SECONDS || '20', 10),
 
-  /** Early stuck threshold in seconds (default: 2 minutes) */
-  EARLY_STUCK_THRESHOLD_SECONDS: parseInt(process.env.EARLY_STUCK_THRESHOLD_SECONDS || '120', 10),
+  /**
+   * No-build-id guard in seconds. It must exceed Jenkins queue polling timeout; otherwise
+   * queued scheduled jobs can be marked aborted before Jenkins assigns a build number.
+   */
+  EARLY_STUCK_THRESHOLD_SECONDS: Math.max(
+    configuredEarlyStuckThresholdSeconds,
+    MIN_EARLY_STUCK_THRESHOLD_SECONDS,
+  ),
 
   /** Stuck threshold in seconds (default: 5 minutes) */
   STUCK_THRESHOLD_SECONDS: parseInt(process.env.STUCK_THRESHOLD_SECONDS || '300', 10),
+
+  /**
+   * Pending runs without start_time/build id are cleaned only after this grace period.
+   * The default follows Jenkins queue polling timeout plus a buffer, with a 60-minute floor.
+   */
+  PENDING_NO_BUILD_CLEANUP_MINUTES: Math.max(
+    configuredPendingNoBuildCleanupMinutes,
+    DEFAULT_PENDING_NO_BUILD_CLEANUP_MINUTES,
+  ),
 
   /** Cleanup interval in milliseconds (default: 1 hour) */
   CLEANUP_INTERVAL: parseInt(process.env.EXECUTION_CLEANUP_INTERVAL || '3600000', 10),
@@ -116,6 +161,7 @@ export const WEBSOCKET_CONFIG = {
 export const MONITORING_CONFIG = {
   HYBRID_SYNC: HYBRID_SYNC_CONFIG,
   EXECUTION_MONITOR: EXECUTION_MONITOR_CONFIG,
+  JENKINS_QUEUE: JENKINS_QUEUE_CONFIG,
   WEBSOCKET: WEBSOCKET_CONFIG,
 } as const;
 
@@ -171,8 +217,16 @@ export function validateMonitoringConfig(): {
     errors.push('QUICK_FAIL_THRESHOLD_SECONDS must be between 5 and 300 seconds');
   }
 
-  if (EXECUTION_MONITOR_CONFIG.EARLY_STUCK_THRESHOLD_SECONDS < 30 || EXECUTION_MONITOR_CONFIG.EARLY_STUCK_THRESHOLD_SECONDS > 600) {
-    errors.push('EARLY_STUCK_THRESHOLD_SECONDS must be between 30 and 600 seconds');
+  if (JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS < 60_000 || JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS > 3_600_000) {
+    errors.push('JENKINS_QUEUE_POLL_TIMEOUT_MS must be between 60000ms (1min) and 3600000ms (60min)');
+  }
+
+  if (EXECUTION_MONITOR_CONFIG.EARLY_STUCK_THRESHOLD_SECONDS > 3_900) {
+    errors.push('EARLY_STUCK_THRESHOLD_SECONDS must be no more than 3900 seconds');
+  }
+
+  if (EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES > 24 * 60) {
+    errors.push('EXECUTION_PENDING_NO_BUILD_CLEANUP_MINUTES must be no more than 1440 minutes');
   }
 
   if (EXECUTION_MONITOR_CONFIG.STUCK_THRESHOLD_SECONDS < 60 || EXECUTION_MONITOR_CONFIG.STUCK_THRESHOLD_SECONDS > 1800) {
@@ -219,7 +273,9 @@ Execution Monitor:
   - Batch Size: ${EXECUTION_MONITOR_CONFIG.BATCH_SIZE}
   - Quick Fail Threshold: ${EXECUTION_MONITOR_CONFIG.QUICK_FAIL_THRESHOLD_SECONDS}s
   - Early Stuck Threshold: ${EXECUTION_MONITOR_CONFIG.EARLY_STUCK_THRESHOLD_SECONDS}s
+  - Pending No-build Cleanup: ${EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES}min
   - Stuck Threshold: ${EXECUTION_MONITOR_CONFIG.STUCK_THRESHOLD_SECONDS}s
+  - Jenkins Queue Poll Timeout: ${JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS}ms
   - Enabled: ${EXECUTION_MONITOR_CONFIG.ENABLED ? 'Yes' : 'No'}
 
 WebSocket:

--- a/server/repositories/ExecutionRepositoryLookup.ts
+++ b/server/repositories/ExecutionRepositoryLookup.ts
@@ -11,6 +11,7 @@ import {
   TestRunResultStatusType,
   TestRunTriggerTypeType,
 } from '../../shared/types/execution';
+import { EXECUTION_MONITOR_CONFIG } from '../config/monitoring';
 import { ExecutionRepositoryBase } from './ExecutionRepositoryBase';
 import type {
   BatchResults,
@@ -356,10 +357,10 @@ export abstract class ExecutionRepositoryLookup extends ExecutionRepositoryBase 
    *   1. start_time 不为 null 且超过 maxAgeHours（正常超时的 running/pending）
    *   2. start_time IS NULL 且 created_at 超过 stuckPendingMinutes（Jenkins 从未触发的 pending，服务重启时队列丢失）
    * @param maxAgeHours        最大运行时长（小时），超过时清理 start_time 不为 null 的记录
-   * @param stuckPendingMinutes Jenkins 未触发的 pending 最长保留时间（分钟），默认 10 分钟
+   * @param stuckPendingMinutes Jenkins 未触发的 pending 最长保留时间（分钟），默认由监控配置控制
    * @returns 更新的执行数量
    */
-  async markOldStuckExecutionsAsAbandoned(maxAgeHours: number = 24, stuckPendingMinutes: number = 10): Promise<number> {
+  async markOldStuckExecutionsAsAbandoned(maxAgeHours: number = 24, stuckPendingMinutes: number = EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES): Promise<number> {
     // 使用原生 SQL 支持 OR 条件，避免 TypeORM QueryBuilder 的 OR 限制
     const result = await this.testRunRepository.query(
       `UPDATE Auto_TestRun
@@ -381,7 +382,7 @@ export abstract class ExecutionRepositoryLookup extends ExecutionRepositoryBase 
   /**
    * 汇总历史卡住记录（用于运行记录页提示条）
    */
-  async getStaleExecutionSummary(maxAgeHours: number = 24, stuckPendingMinutes: number = 10): Promise<StaleExecutionSummary> {
+  async getStaleExecutionSummary(maxAgeHours: number = 24, stuckPendingMinutes: number = EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES): Promise<StaleExecutionSummary> {
     const rows = await this.testRunRepository.query(
       `SELECT
          SUM(

--- a/server/services/ExecutionMonitorService.ts
+++ b/server/services/ExecutionMonitorService.ts
@@ -295,13 +295,18 @@ export class ExecutionMonitorService {
     this.cleanupTimer = setTimeout(async () => {
       try {
         const maxAgeHours = EXECUTION_MONITOR_CONFIG.MAX_AGE_HOURS;
-        const abandonedCount = await this.executionRepository.markOldStuckExecutionsAsAbandoned(maxAgeHours);
+        const pendingNoBuildCleanupMinutes = EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES;
+        const abandonedCount = await this.executionRepository.markOldStuckExecutionsAsAbandoned(
+          maxAgeHours,
+          pendingNoBuildCleanupMinutes,
+        );
 
         if (abandonedCount > 0) {
           logger.info('Cleaned up old stuck executions', {
             event: LOG_EVENTS.MONITOR_CLEANUP_COMPLETED,
             abandonedCount,
             maxAgeHours,
+            pendingNoBuildCleanupMinutes,
           }, LOG_CONTEXTS.MONITOR);
         }
 
@@ -440,9 +445,9 @@ export class ExecutionMonitorService {
     const runId = execution.id;
 
     try {
-      // [dev-11] 兜底处理：如果执行超过 2 分钟仍无 jenkinsBuildId，说明 Jenkins 触发已失败
-      // 正常情况下 pollQueueForBuild 在 60 秒内会解析出 buildId，超过 2 分钟说明已完全丢失
-      const NO_BUILD_ID_TIMEOUT_SECONDS = EXECUTION_MONITOR_CONFIG.EARLY_STUCK_THRESHOLD_SECONDS; // 默认 120s
+      // [dev-11] 兜底处理：如果执行超过配置的受保护队列等待窗口仍无 jenkinsBuildId，说明 Jenkins 触发已失败
+      // 注意：该阈值必须大于 Jenkins Queue 轮询超时，避免 executor 繁忙时把仍在排队的定时任务误标为 aborted。
+      const NO_BUILD_ID_TIMEOUT_SECONDS = EXECUTION_MONITOR_CONFIG.EARLY_STUCK_THRESHOLD_SECONDS;
       if (!execution.jenkinsBuildId && execution.durationSeconds !== null && execution.durationSeconds > NO_BUILD_ID_TIMEOUT_SECONDS) {
         logger.warn('Execution has no jenkinsBuildId after threshold, marking as aborted', {
           event: LOG_EVENTS.MONITOR_EXECUTION_STUCK_DETECTED,

--- a/server/services/ExecutionService/service.ts
+++ b/server/services/ExecutionService/service.ts
@@ -17,6 +17,7 @@ import {
 import { EXECUTION_CONFIG, EXECUTION_STATUS, TEST_RESULT_STATUS } from '../../config/constants';
 import logger from '../../utils/logger';
 import { LOG_CONTEXTS, createTimer } from '../../config/logging';
+import { EXECUTION_MONITOR_CONFIG } from '../../config/monitoring';
 import { ExecutionRepository } from '../../repositories/ExecutionRepository';
 import { dashboardService } from '../DashboardService';
 import { webSocketService } from '../WebSocketService';
@@ -829,14 +830,14 @@ export class ExecutionService {
     );
   }
 
-  async getStaleExecutionSummary(maxAgeHours = 24, stalePendingMinutes = 10) {
+  async getStaleExecutionSummary(maxAgeHours = 24, stalePendingMinutes = EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES) {
     return this.executionRepository.getStaleExecutionSummary(maxAgeHours, stalePendingMinutes);
   }
 
   /**
    * 一次性清理历史卡住执行（pending/running -> aborted）
    */
-  async cleanupStaleExecutions(maxAgeHours = 24, stalePendingMinutes = 10, dryRun = false) {
+  async cleanupStaleExecutions(maxAgeHours = 24, stalePendingMinutes = EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES, dryRun = false) {
     const summary = await this.executionRepository.getStaleExecutionSummary(maxAgeHours, stalePendingMinutes);
 
     if (dryRun) {

--- a/server/services/JenkinsService.ts
+++ b/server/services/JenkinsService.ts
@@ -1,4 +1,5 @@
 import { isMisconfiguredTestRepoUrl, normalizeGitRemoteUrl } from '../utils/jenkinsRepoValidation';
+import { EXECUTION_MONITOR_CONFIG, JENKINS_QUEUE_CONFIG } from '../config/monitoring';
 import { normalizeConfiguredJenkinsBaseUrl } from '../utils/jenkinsUrl';
 import logger from '../utils/logger';
 import { getSecretOrEnv } from '../utils/secrets';
@@ -680,12 +681,14 @@ export class JenkinsService {
                 });
               }
             } else {
-              // 构建被取消或轮询超时：通知调用方将平台执行状态更新为 aborted
+              // 构建被取消或超过受保护的队列等待窗口后，才通知调用方将平台执行状态更新为 aborted
               const reason = buildInfo && 'cancelled' in buildInfo ? 'cancelled' : 'timeout';
-              logger.warn('pollQueueForBuild: build not started', {
+              logger.warn('pollQueueForBuild: build not started within protected queue window', {
                 runId,
                 queueId,
                 reason,
+                queuePollTimeoutMs: JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS,
+                pendingCleanupMinutes: EXECUTION_MONITOR_CONFIG.PENDING_NO_BUILD_CLEANUP_MINUTES,
               }, 'JENKINS');
               if (onBuildCancelled) {
                 onBuildCancelled(reason).catch(err => {
@@ -774,14 +777,14 @@ export class JenkinsService {
    *
    * @param queueId Jenkins 队列项 ID
    * @param runId 平台运行记录 ID（仅用于日志）
-   * @param maxWaitMs 最长等待时间（毫秒），默认 60 秒
+   * @param maxWaitMs 最长等待时间（毫秒），默认由 JENKINS_QUEUE_POLL_TIMEOUT_MS 控制
    * @param pollIntervalMs 轮询间隔（毫秒），默认 3 秒
    * @returns 包含 buildNumber、buildUrl 和 queueWaitMs（队列等待时长）的对象，或 null（超时/取消）
    */
   private async pollQueueForBuild(
     queueId: number,
     runId: number,
-    maxWaitMs = parseInt(process.env.JENKINS_QUEUE_POLL_TIMEOUT_MS || String(5 * 60_000), 10), // 默认等待 5 分钟（可通过环境变量调整）
+    maxWaitMs = JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS, // 默认等待 30 分钟，避免 Jenkins executor 繁忙时误中止定时任务
     pollIntervalMs = 3_000
   ): Promise<{ buildNumber: number; buildUrl: string; queueWaitMs: number } | null | { cancelled: true } | { timeout: true }> {
 


### PR DESCRIPTION
### Motivation

- Scheduled executions were being marked `aborted` while Jenkins was still queued for an executor because the platform's no-build-id / cleanup thresholds were shorter than the Jenkins queue wait window. 
- This caused many legitimate runs to be considered failed/aborted and inflated skipped/aborted statistics on the dashboard. 
- The change aligns platform monitoring/cleanup thresholds with a configurable Jenkins queue polling timeout so runs waiting for a build number are not prematurely aborted.

### Description

- Added `JENKINS_QUEUE_CONFIG` and a `POLL_TIMEOUT_MS` (default 30 minutes) to `server/config/monitoring.ts` and derived safe defaults `EARLY_STUCK_THRESHOLD_SECONDS` and `PENDING_NO_BUILD_CLEANUP_MINUTES` that depend on the queue timeout. 
- Updated Jenkins polling to use `JENKINS_QUEUE_CONFIG.POLL_TIMEOUT_MS` in `server/services/JenkinsService.ts` and changed the cancel/timeout handling and logging to indicate the protected queue window. 
- Aligned monitor/cleanup code to the new settings by passing `PENDING_NO_BUILD_CLEANUP_MINUTES` into `markOldStuckExecutionsAsAbandoned` and by using `EARLY_STUCK_THRESHOLD_SECONDS` in `ExecutionMonitorService`, and adjusted repository/service defaults so manual `cleanup`/`stale-summary` APIs use the safer threshold. 
- Extended configuration validation and the human-readable monitoring summary to include the Jenkins queue timeout and pending-cleanup values.

### Testing

- Ran server typecheck with `npx tsc --noEmit -p tsconfig.server.json` and it completed successfully. 
- Ran backend unit tests with `npx vitest run test_case/backend/callbackStatus.test.ts test_case/backend/routes/tasks.route.test.ts` and the suite passed (`Test Files 2 passed`, `Tests 81 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22a30a0d1c8332b5218c41284d4568)