### PR TITLE
Clarify task status semantics, fix success-rate calc, update docs and tests

### DIFF
--- a/src/components/cases/commonColumns.ts
+++ b/src/components/cases/commonColumns.ts
@@ -60,7 +60,7 @@ export const FULL_COLUMNS: CaseColumn[] = [
 ];
 
 /**
- * 简洁列配置（不含脚本路径和说明）
+ * 简洁列配置（不含说明列）
  * 适用于性能用例页面
  */
 export const SIMPLE_COLUMNS: CaseColumn[] = [

--- a/src/pages/tasks/components/TaskCard.tsx
+++ b/src/pages/tasks/components/TaskCard.tsx
@@ -44,6 +44,7 @@ import {
   TRIGGER_TYPE_LABELS,
 } from '@/constants/tasks';
 import { TASK_MESSAGES, TASK_PAGE } from '@/constants/messages';
+import { getTaskSuccessRate } from './taskPageConfig';
 
 interface TaskCardProps {
   task: Task;
@@ -79,11 +80,7 @@ export const TaskCard = memo(function TaskCard({
   onSelectTask,
 }: TaskCardProps) {
   const [, navigate] = useLocation();
-  const lastExecution = task.recentExecutions?.[0];
-  const successRate =
-    lastExecution?.total_cases
-      ? Math.round((lastExecution.passed_cases / lastExecution.total_cases) * 100)
-      : null;
+  const successRate = getTaskSuccessRate(task);
 
   // 是否有正在运行的执行（用于显示「取消」按钮）
   const hasActiveExecution = task.recentExecutions?.some(

--- a/src/pages/tasks/components/taskPageConfig.ts
+++ b/src/pages/tasks/components/taskPageConfig.ts
@@ -74,6 +74,7 @@ export const TABLE_COLUMN_OPTIONS: ReadonlyArray<{ key: TaskSortKey; label: stri
 export const TASK_STATUS_SEMANTIC = {
   success: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300',
   running: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300',
+  pending: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
   paused: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
   failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
   draft: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
@@ -99,15 +100,20 @@ export const parseCaseCount = (task: Task): number => {
 export const getTaskSuccessRate = (task: Task): number | null => {
   const latest = task.recentExecutions?.[0];
   if (!latest?.total_cases) return null;
-  return Math.round((latest.passed_cases / latest.total_cases) * 100);
+
+  const passedCases = latest.passed_cases ?? 0;
+  return Math.round((passedCases / latest.total_cases) * 100);
 };
 
 export const getTaskSemanticStatus = (task: Task): { key: TaskSemanticStatus; label: string } => {
   if (task.status === 'archived') return { key: 'draft', label: '草稿' };
 
   const latest = task.recentExecutions?.[0];
-  if (latest?.status === 'running' || latest?.status === 'pending') {
+  if (latest?.status === 'running') {
     return { key: 'running', label: '运行中' };
+  }
+  if (latest?.status === 'pending') {
+    return { key: 'pending', label: '排队中' };
   }
   if (task.status === 'paused') return { key: 'paused', label: '暂停' };
   if (latest?.status === 'failed') return { key: 'failed', label: '失败' };

--- a/src/services/authApi.ts
+++ b/src/services/authApi.ts
@@ -233,7 +233,7 @@ export async function login(
       return { success: false, message: '网络错误，请稍后重试' };
     }
 
-    console.warn('Encrypted login unavailable, fallback to plaintext login', {
+    console.warn('Encrypted login unavailable, falling back to plaintext login', {
       reason: error instanceof Error ? error.message : String(error),
     });
 

--- a/test_case/frontend/pages/tasks-utils.test.ts
+++ b/test_case/frontend/pages/tasks-utils.test.ts
@@ -1,228 +1,137 @@
 import { describe, it, expect } from 'vitest';
+import {
+  formatTime,
+  getTaskSemanticStatus,
+  getTaskSuccessRate,
+  parseCaseCount,
+} from '@/pages/tasks/components/taskPageConfig';
+import type { Task, TaskExecution } from '@/hooks/useTasks';
 
-/**
- * Tasks.tsx 工具函数单元测试
- *
- * 测试策略：
- * - 提取 Tasks.tsx 中的纯函数逻辑，独立测试
- * - 不依赖 jsdom / react-testing-library（纯 TS 环境）
- * - 快速验证本次修复的核心逻辑
- */
-
-// ──────────────────────────────────────────────────────────────────────────────
-// 提取自 Tasks.tsx 的纯函数（与页面代码逻辑保持一致）
-// ──────────────────────────────────────────────────────────────────────────────
-
-interface Execution {
-  id: number;
-  status: string;
-  start_time?: string | null;
-  passed_cases?: number;
-  failed_cases?: number;
-  total_cases?: number;
+function makeExecution(overrides: Partial<TaskExecution> = {}): TaskExecution {
+  return {
+    id: 1,
+    status: 'success',
+    passed_cases: 0,
+    failed_cases: 0,
+    total_cases: 0,
+    ...overrides,
+  };
 }
 
-interface Task {
-  id: number;
-  status: string;
-  recentExecutions: Execution[];
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 1,
+    name: '回归任务',
+    trigger_type: 'manual',
+    status: 'active',
+    updated_at: '2026-01-01T00:00:00Z',
+    recentExecutions: [],
+    ...overrides,
+  };
 }
 
-interface SemanticStatus {
-  key: string;
-  label: string;
-}
+describe('taskPageConfig - getTaskSemanticStatus', () => {
+  it('active 任务从未执行过时应返回“空闲”', () => {
+    const result = getTaskSemanticStatus(makeTask());
 
-/**
- * 与 Tasks.tsx 中 getTaskSemanticStatus 完全一致的逻辑（修复后版本）
- */
-function getTaskSemanticStatus(task: Task): SemanticStatus {
-  const latest = task.recentExecutions?.[0];
-
-  if (task.status === 'paused') return { key: 'paused', label: '暂停' };
-  if (latest?.status === 'running') return { key: 'running', label: '运行中' };
-  if (latest?.status === 'pending') return { key: 'pending', label: '排队中' };
-  if (latest?.status === 'failed') return { key: 'failed', label: '失败' };
-  // 从未执行过时（latest 为空），显示"空闲"而非"成功"，避免语义误导
-  if (!latest) return { key: 'draft', label: '空闲' };
-  return { key: 'success', label: '成功' };
-}
-
-/**
- * 与 Tasks.tsx 中 formatTime 完全一致的逻辑（修复后版本）
- */
-function formatTime(value?: string | null): string {
-  if (!value) return '-';
-  const d = new Date(value);
-  if (isNaN(d.getTime())) return '-';
-  return d.toLocaleString('zh-CN', {
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
-
-/**
- * failedTaskIds 安全访问（修复后版本）
- */
-function buildFailureDescription(failedTaskIds: number[] | undefined): string {
-  const failedIds = failedTaskIds ?? [];
-  const previewFailedIds = failedIds.slice(0, 5).join(', ');
-  const hasMore = failedIds.length > 5;
-  return failedIds.length > 0
-    ? `失败任务ID: ${previewFailedIds}${hasMore ? ' ...' : ''}`
-    : '请重试或查看后端日志';
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-
-describe('Tasks.tsx - getTaskSemanticStatus（空闲态修复）', () => {
-  it('active 任务从未执行过时应返回"空闲"', () => {
-    const task: Task = { id: 1, status: 'active', recentExecutions: [] };
-    const result = getTaskSemanticStatus(task);
-    expect(result.key).toBe('draft');
-    expect(result.label).toBe('空闲');
+    expect(result).toEqual({ key: 'draft', label: '空闲' });
   });
 
-  it('active 任务最近一次执行成功时应返回"成功"', () => {
-    const task: Task = {
-      id: 1,
-      status: 'active',
-      recentExecutions: [{ id: 1, status: 'success' }],
-    };
-    const result = getTaskSemanticStatus(task);
-    expect(result.key).toBe('success');
-    expect(result.label).toBe('成功');
+  it('active 任务最近一次执行成功时应返回“成功”', () => {
+    const result = getTaskSemanticStatus(
+      makeTask({ recentExecutions: [makeExecution({ status: 'success' })] })
+    );
+
+    expect(result).toEqual({ key: 'success', label: '成功' });
   });
 
-  it('active 任务最近一次执行失败时应返回"失败"', () => {
-    const task: Task = {
-      id: 1,
-      status: 'active',
-      recentExecutions: [{ id: 1, status: 'failed' }],
-    };
-    const result = getTaskSemanticStatus(task);
-    expect(result.key).toBe('failed');
-    expect(result.label).toBe('失败');
+  it('active 任务最近一次执行失败时应返回“失败”', () => {
+    const result = getTaskSemanticStatus(
+      makeTask({ recentExecutions: [makeExecution({ status: 'failed' })] })
+    );
+
+    expect(result).toEqual({ key: 'failed', label: '失败' });
   });
 
-  it('paused 任务应返回"暂停"（无论 recentExecutions）', () => {
-    const taskEmpty: Task = { id: 1, status: 'paused', recentExecutions: [] };
-    const taskWithRun: Task = {
-      id: 1,
+  it('paused 任务应返回“暂停”（无论 recentExecutions）', () => {
+    const taskEmpty = makeTask({ status: 'paused', recentExecutions: [] });
+    const taskWithRun = makeTask({
       status: 'paused',
-      recentExecutions: [{ id: 1, status: 'success' }],
-    };
+      recentExecutions: [makeExecution({ status: 'success' })],
+    });
+
     expect(getTaskSemanticStatus(taskEmpty).label).toBe('暂停');
     expect(getTaskSemanticStatus(taskWithRun).label).toBe('暂停');
   });
 
-  it('active 任务正在运行时应返回"运行中"', () => {
-    const task: Task = {
-      id: 1,
-      status: 'active',
-      recentExecutions: [{ id: 1, status: 'running' }],
-    };
-    expect(getTaskSemanticStatus(task).label).toBe('运行中');
+  it('running 执行应显示“运行中”', () => {
+    const result = getTaskSemanticStatus(
+      makeTask({ recentExecutions: [makeExecution({ status: 'running' })] })
+    );
+
+    expect(result).toEqual({ key: 'running', label: '运行中' });
   });
 
-  it('active 任务排队中时应返回"排队中"', () => {
-    const task: Task = {
-      id: 1,
-      status: 'active',
-      recentExecutions: [{ id: 1, status: 'pending' }],
-    };
-    expect(getTaskSemanticStatus(task).label).toBe('排队中');
-  });
+  it('pending 执行应显示“排队中”，避免与运行中混淆', () => {
+    const result = getTaskSemanticStatus(
+      makeTask({ recentExecutions: [makeExecution({ status: 'pending' })] })
+    );
 
-  it('修复前的语义问题：recentExecutions 为空时不应错误地返回"成功"', () => {
-    // 这是修复前的 bug：active + no executions => 成功（错误）
-    // 修复后应返回：空闲
-    const task: Task = { id: 1, status: 'active', recentExecutions: [] };
-    const result = getTaskSemanticStatus(task);
-    expect(result.label).not.toBe('成功'); // 修复后不再是"成功"
-    expect(result.label).toBe('空闲');
+    expect(result).toEqual({ key: 'pending', label: '排队中' });
   });
 });
 
-// ──────────────────────────────────────────────────────────────────────────────
+describe('taskPageConfig - getTaskSuccessRate', () => {
+  it('无执行记录时返回 null', () => {
+    expect(getTaskSuccessRate(makeTask())).toBeNull();
+  });
 
-describe('Tasks.tsx - formatTime（无效日期守护）', () => {
-  it('空字符串应返回"-"', () => {
+  it('total_cases 为 0 时返回 null', () => {
+    expect(
+      getTaskSuccessRate(makeTask({ recentExecutions: [makeExecution({ passed_cases: 0, total_cases: 0 })] }))
+    ).toBeNull();
+  });
+
+  it('按最近一次执行记录计算成功率', () => {
+    expect(
+      getTaskSuccessRate(makeTask({ recentExecutions: [makeExecution({ passed_cases: 7, total_cases: 10 })] }))
+    ).toBe(70);
+  });
+
+  it('passed_cases 缺失时按 0 处理，避免表格显示 NaN%', () => {
+    const execution = {
+      id: 1,
+      status: 'success',
+      failed_cases: 3,
+      total_cases: 3,
+    } as TaskExecution;
+
+    expect(getTaskSuccessRate(makeTask({ recentExecutions: [execution] }))).toBe(0);
+  });
+});
+
+describe('taskPageConfig - parseCaseCount', () => {
+  it('case_ids 为空或非法 JSON 时返回 0', () => {
+    expect(parseCaseCount(makeTask({ case_ids: undefined }))).toBe(0);
+    expect(parseCaseCount(makeTask({ case_ids: '{bad json' }))).toBe(0);
+  });
+
+  it('case_ids 为数组 JSON 时返回关联用例数量', () => {
+    expect(parseCaseCount(makeTask({ case_ids: '[1,2,3]' }))).toBe(3);
+  });
+});
+
+describe('taskPageConfig - formatTime', () => {
+  it('空值或非法日期应返回“-”', () => {
     expect(formatTime('')).toBe('-');
-  });
-
-  it('null 应返回"-"', () => {
-    expect(formatTime(null)).toBe('-');
-  });
-
-  it('undefined 应返回"-"', () => {
     expect(formatTime(undefined)).toBe('-');
-  });
-
-  it('非法日期字符串应返回"-"而非"Invalid Date"', () => {
     expect(formatTime('not-a-date')).toBe('-');
-    expect(formatTime('invalid')).toBe('-');
-    expect(formatTime('2023-13-45')).toBe('-'); // 月份超范围
   });
 
-  it('有效日期字符串不应返回"-"', () => {
+  it('有效日期字符串不应返回“-”或 Invalid Date', () => {
     const result = formatTime('2026-01-15T10:30:00Z');
+
     expect(result).not.toBe('-');
     expect(result).not.toContain('Invalid Date');
-  });
-
-  it('修复验证：任何情况下都不应输出"Invalid Date"', () => {
-    const testCases = [
-      'not-a-valid-date',
-      'abc',
-      '00/00/0000',
-      '',
-      null,
-      undefined,
-    ];
-    for (const tc of testCases) {
-      const result = formatTime(tc as string);
-      expect(result, `formatTime("${tc}") should not be "Invalid Date"`).not.toContain('Invalid Date');
-    }
-  });
-});
-
-// ──────────────────────────────────────────────────────────────────────────────
-
-describe('Tasks.tsx - failedTaskIds 安全访问', () => {
-  it('failedTaskIds 为 undefined 时应使用空数组兜底', () => {
-    const result = buildFailureDescription(undefined);
-    expect(result).toBe('请重试或查看后端日志');
-  });
-
-  it('failedTaskIds 为空数组时应显示默认提示', () => {
-    const result = buildFailureDescription([]);
-    expect(result).toBe('请重试或查看后端日志');
-  });
-
-  it('failedTaskIds 有内容时应显示失败任务 ID', () => {
-    const result = buildFailureDescription([1, 2, 3]);
-    expect(result).toContain('失败任务ID');
-    expect(result).toContain('1');
-    expect(result).toContain('2');
-    expect(result).toContain('3');
-    expect(result).not.toContain('...');
-  });
-
-  it('failedTaskIds 超过5个时应显示省略号', () => {
-    const result = buildFailureDescription([1, 2, 3, 4, 5, 6, 7]);
-    expect(result).toContain('...');
-    // 只展示前5个
-    expect(result).toContain('1');
-    expect(result).toContain('5');
-  });
-
-  it('修复前的潜在 crash：failedTaskIds 为 undefined 时直接 .slice() 会报错', () => {
-    // 修复前：result.failedTaskIds.slice(0, 5) 在 failedTaskIds=undefined 时会抛 TypeError
-    // 修复后：result.failedTaskIds ?? [] 安全兜底
-    expect(() => buildFailureDescription(undefined)).not.toThrow();
-    expect(() => buildFailureDescription(null as unknown as number[])).not.toThrow();
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent UI and semantics confusion by distinguishing queued (`pending`) executions from actively running (`running`) executions. 
- Avoid showing `NaN%` for task success rate when `passed_cases` is missing. 
- Fix a small wording/typo and align a column comment with the actual columns. 
- Improve unit tests to exercise the exported helpers and cover the above fixes.

### Description
- Split `pending` vs `running` handling in `getTaskSemanticStatus` and add a `pending` entry to `TASK_STATUS_SEMANTIC` so queued tasks show as “排队中”.
- Centralized success-rate logic into `getTaskSuccessRate` inside `src/pages/tasks/components/taskPageConfig.ts`, and guard `passed_cases` with `?? 0`; `TaskCard` now reuses this helper.
- Corrected an auth log message in `src/services/authApi.ts` from "fallback to plaintext" to "falling back to plaintext" and updated `SIMPLE_COLUMNS` comment in `src/components/cases/commonColumns.ts` to match the actual columns.
- Replaced/updated the frontend test `test_case/frontend/pages/tasks-utils.test.ts` to import the real exported helpers from `taskPageConfig` and added cases for `pending` status and missing `passed_cases`.

### Testing
- Ran `npx vitest run test_case/frontend/pages/tasks-utils.test.ts` and the suite passed (`14 tests` passed).
- Ran type checking with `npx tsc --noEmit -p tsconfig.json` which completed successfully. 
- Ran a production build with `npm run build` which completed (build warnings only) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22c6b5cc6c8332b31566285cb422a7)