### PR TITLE
Fix layout for AI 工作台「需求输入与解析」 — full-width responsive three-column layout

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,7 +18,7 @@ export function Layout({ children }: LayoutProps) {
       {/* ── Main Content ── */}
       {/* No top header bar — content starts from the very top of the viewport */}
       <main className="flex-1 flex flex-col h-full overflow-hidden min-w-0">
-        <div className="flex-1 overflow-y-auto h-full">
+        <div className="h-full min-w-0 flex-1 overflow-y-auto">
           {children}
         </div>
       </main>

--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { ClipboardList, Play, Save } from "lucide-react";
+import { AlertTriangle, Blocks, ClipboardList, FileQuestion, Play, Save, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import CleanRulesPanel from "@/pages/cases/components/CleanRulesPanel";
@@ -19,6 +19,85 @@ import {
 } from "@/pages/cases/requirementInputUtils";
 
 const textFileTypes = new Set(["markdown", "text", "excel"]);
+
+interface ParseAnalysisPanelProps {
+  wordCount: number;
+}
+
+function ParseAnalysisPanel({ wordCount }: ParseAnalysisPanelProps) {
+  const summaryItems = [
+    { label: "文档字数", value: wordCount },
+    { label: "识别模块", value: 0 },
+    { label: "需求疑问", value: 0 },
+    { label: "风险点", value: 0 },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <section className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-[#39E079]/10 text-[#2ba85a] dark:bg-[#39E079]/15 dark:text-[#39E079]">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">
+            解析结果摘要
+          </h3>
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          {summaryItems.map((item) => (
+            <div className="rounded-xl border border-slate-100 bg-slate-50/50 p-3 dark:border-slate-800/60 dark:bg-slate-900/30" key={item.label}>
+              <p className="text-xs text-slate-400 dark:text-slate-500">{item.label}</p>
+              <p className="mt-1 font-display text-xl font-semibold text-slate-900 dark:text-white">{item.value}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+        <div className="mb-3 flex items-center gap-2.5">
+          <Blocks className="h-4 w-4 text-blue-500 dark:text-blue-400" />
+          <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">识别到的功能模块</h3>
+        </div>
+        <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/50 px-4 py-6 text-center text-xs text-slate-400 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-500">
+          暂无模块，开始解析后展示
+        </div>
+      </section>
+
+      <section className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+        <div className="mb-3 flex items-center gap-2.5">
+          <FileQuestion className="h-4 w-4 text-amber-500 dark:text-amber-400" />
+          <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">需求疑问</h3>
+        </div>
+        <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/50 px-4 py-6 text-center text-xs text-slate-400 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-500">
+          暂无疑问，开始解析后展示
+        </div>
+      </section>
+
+      <section className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+        <div className="mb-3 flex items-center gap-2.5">
+          <AlertTriangle className="h-4 w-4 text-orange-500 dark:text-orange-400" />
+          <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">风险提示</h3>
+        </div>
+        <div className="rounded-xl border border-dashed border-slate-200 bg-slate-50/50 px-4 py-6 text-center text-xs text-slate-400 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-500">
+          暂无风险点，开始解析后展示
+        </div>
+      </section>
+
+      <section className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+        <h3 className="mb-4 font-display text-sm font-semibold text-slate-900 dark:text-white">下一步操作</h3>
+        <div className="grid gap-3">
+          <Button className="h-9 w-full rounded-lg bg-[#39E079] text-sm font-semibold text-[#0a2010] hover:bg-[#32c96b]" type="button">
+            生成测试点
+          </Button>
+          <Button className="h-9 w-full rounded-lg border border-slate-200 bg-white text-sm font-medium text-slate-700 shadow-none hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200" type="button" variant="outline">
+            查看解析报告
+          </Button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
 
 function readFileAsText(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -92,10 +171,10 @@ function RequirementInputParsePage() {
   };
 
   return (
-    <div className="min-h-screen bg-[#f6f7f9] font-body dark:bg-[#0c0f1a]">
+    <div className="min-h-full w-full min-w-0 bg-[#f6f7f9] font-body dark:bg-[#0c0f1a]">
       {/* Header */}
       <header className="border-b border-slate-200/60 bg-white/80 backdrop-blur-sm dark:border-slate-800/60 dark:bg-[#131729]/80">
-        <div className="mx-auto flex max-w-[1440px] items-center justify-between px-8 py-5">
+        <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-4 px-6 py-5">
           <div className="flex items-center gap-4">
             <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#39E079]/10 text-[#2ba85a] dark:bg-[#39E079]/15 dark:text-[#39E079]">
               <ClipboardList className="h-5 w-5" />
@@ -136,25 +215,30 @@ function RequirementInputParsePage() {
       </header>
 
       {/* Content */}
-      <main className="mx-auto max-w-[1440px] px-8 py-8">
-        <div className="grid gap-8 xl:grid-cols-[380px_1fr]">
+      <main className="w-full min-w-0 p-6">
+        <div className="grid w-full min-w-0 grid-cols-1 items-start gap-6 xl:grid-cols-[300px_minmax(0,1fr)] 2xl:grid-cols-[320px_minmax(0,1fr)_320px]">
           {/* Left column */}
-          <div className="space-y-6">
+          <aside className="w-full space-y-4">
             <RequirementUploadPanel onFilesSelected={handleFilesSelected} />
             <UploadedFileList
               files={files}
               onRemove={(id) => setFiles((currentFiles) => currentFiles.filter((file) => file.id !== id))}
             />
             <CleanRulesPanel rules={rules} onChange={setRules} />
-          </div>
+          </aside>
 
-          {/* Right column */}
-          <div className="space-y-6">
+          {/* Main parse column */}
+          <section className="min-w-0 space-y-4">
             <RequirementConfigForm config={config} onChange={setConfig} />
             <RequirementTextEditor value={rawText} onChange={setRawText} />
             <ParseProgressSteps progress={progress} />
             <RequirementContentCompare rawText={rawText} cleanedText={cleanedText} wordCount={wordCount} />
-          </div>
+          </section>
+
+          {/* Analysis column */}
+          <aside className="w-full space-y-4 xl:col-span-2 2xl:col-span-1">
+            <ParseAnalysisPanel wordCount={wordCount} />
+          </aside>
         </div>
       </main>
     </div>

--- a/src/pages/cases/components/CleanRulesPanel.tsx
+++ b/src/pages/cases/components/CleanRulesPanel.tsx
@@ -18,7 +18,7 @@ function CleanRulesPanel({ rules, onChange }: CleanRulesPanelProps) {
   const activeCount = ruleItems.filter((item) => rules[item.key]).length;
 
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">
           清洗规则

--- a/src/pages/cases/components/ParseProgressSteps.tsx
+++ b/src/pages/cases/components/ParseProgressSteps.tsx
@@ -14,7 +14,7 @@ const steps = [
 
 function ParseProgressSteps({ progress }: ParseProgressStepsProps) {
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <div className="mb-4 flex items-center justify-between">
         <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">
           解析进度

--- a/src/pages/cases/components/RequirementConfigForm.tsx
+++ b/src/pages/cases/components/RequirementConfigForm.tsx
@@ -21,7 +21,7 @@ function RequirementConfigForm({ config, onChange }: RequirementConfigFormProps)
   };
 
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <h3 className="mb-4 font-display text-sm font-semibold text-slate-900 dark:text-white">
         解析配置
       </h3>

--- a/src/pages/cases/components/RequirementContentCompare.tsx
+++ b/src/pages/cases/components/RequirementContentCompare.tsx
@@ -11,7 +11,7 @@ function RequirementContentCompare({ rawText, cleanedText, wordCount }: Requirem
   const cleanLineCount = cleanedText ? cleanedText.split("\n").length : 0;
 
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <div className="mb-4 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">
@@ -32,12 +32,12 @@ function RequirementContentCompare({ rawText, cleanedText, wordCount }: Requirem
           </span>
         )}
       </div>
-      <div className="grid gap-4 lg:grid-cols-2">
-        <div className="relative">
+      <div className="grid min-w-0 grid-cols-1 gap-4 lg:grid-cols-2">
+        <div className="relative min-w-0">
           <div className="absolute left-3 top-3 text-[10px] font-medium uppercase tracking-wider text-slate-400/60 dark:text-slate-500/60">
             原始
           </div>
-          <pre className="min-h-[280px] overflow-auto rounded-xl border border-slate-100 bg-slate-50/50 p-4 pt-7 font-mono text-xs leading-6 text-slate-600 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-300">
+          <pre className="min-h-[280px] overflow-auto whitespace-pre-wrap rounded-xl border border-slate-100 bg-slate-50/50 p-4 pt-7 font-mono text-xs leading-6 text-slate-600 dark:border-slate-800 dark:bg-slate-900/30 dark:text-slate-300">
             {rawText || (
               <span className="text-slate-300 dark:text-slate-600">
                 暂无原始需求内容
@@ -45,11 +45,11 @@ function RequirementContentCompare({ rawText, cleanedText, wordCount }: Requirem
             )}
           </pre>
         </div>
-        <div className="relative">
+        <div className="relative min-w-0">
           <div className="absolute left-3 top-3 text-[10px] font-medium uppercase tracking-wider text-[#2ba85a]/60 dark:text-[#39E079]/60">
             清洗后
           </div>
-          <pre className="min-h-[280px] overflow-auto rounded-xl border border-[#39E079]/10 bg-[#39E079]/5 p-4 pt-7 font-mono text-xs leading-6 text-slate-700 dark:border-[#39E079]/10 dark:bg-[#39E079]/5 dark:text-slate-200">
+          <pre className="min-h-[280px] overflow-auto whitespace-pre-wrap rounded-xl border border-[#39E079]/10 bg-[#39E079]/5 p-4 pt-7 font-mono text-xs leading-6 text-slate-700 dark:border-[#39E079]/10 dark:bg-[#39E079]/5 dark:text-slate-200">
             {cleanedText || (
               <span className="text-slate-300 dark:text-slate-600">
                 清洗后内容将在这里展示

--- a/src/pages/cases/components/RequirementTextEditor.tsx
+++ b/src/pages/cases/components/RequirementTextEditor.tsx
@@ -9,7 +9,7 @@ function RequirementTextEditor({ value, onChange }: RequirementTextEditorProps) 
   const lineCount = value ? value.split("\n").length : 0;
 
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <div className="mb-4 flex items-center justify-between">
         <div>
           <h3 className="font-display text-sm font-semibold text-slate-900 dark:text-white">
@@ -26,7 +26,7 @@ function RequirementTextEditor({ value, onChange }: RequirementTextEditorProps) 
         )}
       </div>
       <Textarea
-        className="min-h-[280px] resize-y rounded-xl border-slate-200 bg-slate-50/30 font-mono text-sm leading-6 transition-colors focus:bg-white dark:border-slate-700 dark:bg-slate-900/30 dark:focus:bg-slate-900/60"
+        className="w-full min-h-[280px] resize-y rounded-xl border-slate-200 bg-slate-50/30 font-mono text-sm leading-6 transition-colors focus:bg-white dark:border-slate-700 dark:bg-slate-900/30 dark:focus:bg-slate-900/60"
         placeholder={`示例：\n作为运营人员，我希望可以批量导入优惠券规则...\n\n| 字段 | 说明 |\n| --- | --- |\n| 优惠类型 | 满减/折扣/免运费 |`}
         value={value}
         onChange={(event) => onChange(event.target.value)}

--- a/src/pages/cases/components/RequirementUploadPanel.tsx
+++ b/src/pages/cases/components/RequirementUploadPanel.tsx
@@ -7,7 +7,7 @@ interface RequirementUploadPanelProps {
 
 function RequirementUploadPanel({ onFilesSelected }: RequirementUploadPanelProps) {
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <div className="mb-4 flex items-center gap-3">
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-950/40">
           <UploadCloud className="h-4 w-4 text-blue-500 dark:text-blue-400" />

--- a/src/pages/cases/components/UploadedFileList.tsx
+++ b/src/pages/cases/components/UploadedFileList.tsx
@@ -18,7 +18,7 @@ interface UploadedFileListProps {
 
 function UploadedFileList({ files, onRemove }: UploadedFileListProps) {
   return (
-    <div className="rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
+    <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <h3 className="mb-3 font-display text-sm font-semibold text-slate-900 dark:text-white">
         已上传文件
         {files.length > 0 && (


### PR DESCRIPTION
### Motivation

- 解决页面在宽屏下两侧出现大量空白的问题，确保主内容区域能充分利用侧边栏剩余宽度并消除固定 max-width / mx-auto 导致的居中留白。 
- 保持左侧全局菜单不变，同时在宽屏下提供右侧分析面板或在无内容时让中间内容扩展占满。 
- 避免 grid / flex 溢出，确保组件可缩放（`min-w-0` / `w-full`）并在 1440/1600/1920 等宽度下正常展示。 

### Description

- 将页面外层从固定居中容器（`mx-auto max-w-[1440px]`）替换为全宽自适应容器（`w-full min-w-0 p-6`），并调整 header 容器为 `flex w-full min-w-0` 以移除两侧大空白（修改文件 `src/pages/cases/RequirementInputParsePage.tsx`）。
- 使用响应式 grid 布局实现左/中/右列结构：在小屏为单栏、`xl` 为两列（左 300px + 主内容）和 `2xl` 为三栏（`320px_minmax(0,1fr)_320px`），左侧为上传/清洗控件，中间为解析内容，右侧为分析面板；同时新增 `ParseAnalysisPanel` 用于右侧摘要（新增并修改于 `RequirementInputParsePage.tsx`）。
- 为避免空占位与溢出，向主布局容器与卡片组件添加 `min-w-0` / `w-full` / `whitespace-pre-wrap` 等样式，调整的组件包括 `Layout.tsx`、`RequirementUploadPanel`、`UploadedFileList`、`CleanRulesPanel`、`RequirementConfigForm`、`RequirementTextEditor`、`ParseProgressSteps`、`RequirementContentCompare`（见对应文件修改列表）。
- 未修改任何业务逻辑，仅调整样式与 DOM 容器结构以满足三栏/两栏布局与响应式断点要求。 

### Testing

- 运行类型检查：`npx tsc --noEmit -p tsconfig.json`，类型检查通过。 
- 本地打包验证：`npm run build`（Vite），构建成功并生成输出。 
- 单元/集成测试：`npx vitest run`，测试套件通过（Test Files 18 passed / Tests 361 passed）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b4d8fb448332bee3f7abd96f1589)