### PR TITLE
修复 AI 工作台「历史记录与导出」页面宽屏布局与右侧面板

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -18,7 +18,7 @@ export function Layout({ children }: LayoutProps) {
       {/* ── Main Content ── */}
       {/* No top header bar — content starts from the very top of the viewport */}
       <main className="flex-1 flex flex-col h-full overflow-hidden min-w-0">
-        <div className="flex-1 overflow-y-auto h-full">
+        <div className="h-full min-w-0 flex-1 overflow-y-auto bg-slate-50">
           {children}
         </div>
       </main>

--- a/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
+++ b/src/pages/ai-workbench/AiWorkbenchHistoryExport.tsx
@@ -8,11 +8,13 @@ import { computeProgress } from '@/lib/aiCaseMindMap';
 import type { AiCaseWorkspaceDocument } from '@/types/aiCases';
 
 import DetailDrawer from './history-export/components/DetailDrawer';
+import ExportOverviewCard from './history-export/components/ExportOverviewCard';
 import ExportCenter from './history-export/components/ExportCenter';
 import HistoryTable from './history-export/components/HistoryTable';
 import RecentExportList from './history-export/components/RecentExportList';
 import StatCard from './history-export/components/StatCard';
 import SyncPanel from './history-export/components/SyncPanel';
+import VersionCompareCard from './history-export/components/VersionCompareCard';
 import VersionComparePanel from './history-export/components/VersionComparePanel';
 import VersionDiffModal from './history-export/components/VersionDiffModal';
 import { exportFormats, recentExports, versionRecords } from './history-export/mock';
@@ -56,7 +58,7 @@ function resolveHistoryStatus(doc: AiCaseWorkspaceDocument): HistoryStatus {
   }
 
   if (progress.doing > 0) {
-    return 'processing';
+    return 'draft';
   }
 
   return 'success';
@@ -72,6 +74,7 @@ function mapDocumentToHistoryRecord(doc: AiCaseWorkspaceDocument): HistoryRecord
     projectName: doc.name || 'AI Testcase Workspace',
     requirementName: extractRequirementName(doc),
     generatedContent: `${progress.total} 条测试点 / 已完成 ${progress.done} / 待处理 ${progress.todo}`,
+    testPointCount: progress.total,
     caseCount: progress.total,
     status: resolveHistoryStatus(doc),
     owner: syncLabel,
@@ -152,7 +155,7 @@ export default function AiWorkbenchHistoryExport(): JSX.Element {
   }, []);
 
   const handleExport = (format: ExportFormatOption): void => {
-    toast.success(`已开始导出 ${format.format} 文件`);
+    toast.success(format.format === '测试平台同步' ? '已创建测试平台同步任务' : `已开始导出 ${format.format} 文件`);
   };
 
   const handleRestore = (version: VersionRecord): void => {
@@ -170,59 +173,68 @@ export default function AiWorkbenchHistoryExport(): JSX.Element {
     }, 1000);
   };
 
+  const pendingSyncCount = docs.filter((doc) => !doc.remoteWorkspaceId).length;
+
   return (
     <>
-      <div className="mx-auto max-w-[1480px] space-y-6 px-6 py-6">
-        <div className="flex items-end justify-between">
-          <div>
+      <div className="w-full min-w-0 p-6 space-y-6">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0">
             <p className="text-sm font-semibold text-[#2563EB]">页面 6 / 6 · 历史记录与导出</p>
             <h1 className="mt-2 text-3xl font-bold tracking-tight text-slate-950">历史记录与导出</h1>
-            <p className="mt-2 text-sm text-slate-500">统一管理 AI 生成历史、版本差异、导出任务与用例同步状态。</p>
+            <p className="mt-2 text-sm text-slate-500">统一管理 AI 生成历史、版本差异、导出任务与同步状态。</p>
           </div>
-          <button className="rounded-xl border border-[#E5E7EB] bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:border-blue-200 hover:text-[#2563EB]" type="button">
+          <button
+            className="w-fit rounded-xl border border-[#E5E7EB] bg-white px-4 py-2 text-sm font-semibold text-slate-700 shadow-sm hover:border-blue-200 hover:text-[#2563EB]"
+            type="button"
+            onClick={() => toast.success('已开始导出审计日志')}
+          >
             导出审计日志
           </button>
         </div>
 
-        <div className="grid grid-cols-4 gap-4">
-          {workspaceStatItems.map((item) => <StatCard item={item} key={item.id} />)}
-        </div>
-
-        <div className="rounded-xl border border-[#E5E7EB] bg-white p-1 shadow-sm">
-          <div className="flex gap-1">
-            {tabs.map((tab) => (
-              <button
-                className={`rounded-lg px-5 py-2.5 text-sm font-semibold transition ${activeTab === tab.id ? 'bg-[#2563EB] text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900'}`}
-                key={tab.id}
-                type="button"
-                onClick={() => setActiveTab(tab.id)}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {activeTab === 'history' ? (
-          <HistoryTable
-            loading={loadingHistory}
-            records={historyRecords}
-            onDeleteRecord={(record) => { void handleDeleteRecord(record); }}
-            onRefresh={() => { void loadHistory(); }}
-            onResume={handleOpenRecord}
-            onViewDetail={setSelectedRecord}
-          />
-        ) : null}
-        {activeTab === 'versions' ? <VersionComparePanel versions={versionRecords} onCompare={() => setDiffOpen(true)} onRestore={handleRestore} /> : null}
-        {activeTab === 'exports' ? (
-          <div className="space-y-6">
-            <ExportCenter formats={exportFormats} onExport={handleExport} />
-            <div className="grid grid-cols-[1fr_0.85fr] gap-6">
-              <RecentExportList exports={recentExports} />
-              <SyncPanel isSyncing={isSyncing} onSync={handleSync} />
+        <div className="grid grid-cols-1 items-start gap-6 2xl:grid-cols-[minmax(0,1fr)_360px]">
+          <section className="min-w-0 space-y-6">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+              {workspaceStatItems.map((item) => <StatCard item={item} key={item.id} />)}
             </div>
-          </div>
-        ) : null}
+
+            <div className="w-full rounded-xl border border-[#E5E7EB] bg-white p-1 shadow-sm">
+              <div className="grid grid-cols-3 gap-1 sm:flex">
+                {tabs.map((tab) => (
+                  <button
+                    className={`rounded-lg px-5 py-2.5 text-sm font-semibold transition ${activeTab === tab.id ? 'bg-[#2563EB] text-white shadow-sm' : 'text-slate-500 hover:bg-slate-50 hover:text-slate-900'}`}
+                    key={tab.id}
+                    type="button"
+                    onClick={() => setActiveTab(tab.id)}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <HistoryTable
+              loading={loadingHistory}
+              records={historyRecords}
+              onDeleteRecord={(record) => { void handleDeleteRecord(record); }}
+              onRefresh={() => { void loadHistory(); }}
+              onResume={handleOpenRecord}
+              onViewDetail={setSelectedRecord}
+            />
+
+            <ExportCenter formats={exportFormats} onExport={handleExport} />
+
+            <VersionComparePanel versions={versionRecords} onCompare={() => setDiffOpen(true)} onRestore={handleRestore} />
+          </section>
+
+          <aside className="min-w-0 space-y-6 2xl:w-[360px]">
+            <ExportOverviewCard pendingSyncCount={pendingSyncCount} />
+            <RecentExportList exports={recentExports} />
+            <VersionCompareCard onCompare={() => setDiffOpen(true)} />
+            <SyncPanel isSyncing={isSyncing} onSync={handleSync} />
+          </aside>
+        </div>
       </div>
       <DetailDrawer record={selectedRecord} onClose={() => setSelectedRecord(null)} />
       <VersionDiffModal open={diffOpen} onClose={() => setDiffOpen(false)} />

--- a/src/pages/ai-workbench/history-export/components/DetailDrawer.tsx
+++ b/src/pages/ai-workbench/history-export/components/DetailDrawer.tsx
@@ -20,6 +20,7 @@ export default function DetailDrawer({ record, onClose }: DetailDrawerProps): JS
     { label: '项目名称', value: record.projectName },
     { label: '需求名称', value: record.requirementName },
     { label: '生成内容', value: record.generatedContent },
+    { label: '测试点数', value: `${record.testPointCount} 条` },
     { label: '用例数量', value: `${record.caseCount} 条` },
     { label: '保存位置', value: record.owner },
     { label: '生成耗时', value: record.duration },

--- a/src/pages/ai-workbench/history-export/components/ExportCenter.tsx
+++ b/src/pages/ai-workbench/history-export/components/ExportCenter.tsx
@@ -7,16 +7,16 @@ export interface ExportCenterProps {
 
 export default function ExportCenter({ formats, onExport }: ExportCenterProps): JSX.Element {
   return (
-    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+    <section className="w-full rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
       <div className="mb-5">
         <h2 className="text-lg font-bold text-slate-950">导出中心</h2>
-        <p className="mt-1 text-sm text-slate-500">选择 Excel、Markdown、JSON、PDF 四种格式生成下载任务。</p>
+        <p className="mt-1 text-sm text-slate-500">选择 Excel、Markdown、JSON 或测试平台同步生成导出任务。</p>
       </div>
-      <div className="grid grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
         {formats.map((format) => {
           const Icon = format.icon;
           return (
-            <button className="rounded-xl border border-[#E5E7EB] bg-white p-4 text-left transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md" key={format.format} type="button" onClick={() => onExport(format)}>
+            <button className="w-full rounded-xl border border-[#E5E7EB] bg-white p-4 text-left transition hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md" key={format.format} type="button" onClick={() => onExport(format)}>
               <span className="mb-4 flex h-11 w-11 items-center justify-center rounded-xl bg-blue-50 text-[#2563EB]">
                 <Icon className="h-5 w-5" />
               </span>

--- a/src/pages/ai-workbench/history-export/components/ExportOverviewCard.tsx
+++ b/src/pages/ai-workbench/history-export/components/ExportOverviewCard.tsx
@@ -1,0 +1,46 @@
+import { FileJson, FileSpreadsheet, FileText } from 'lucide-react';
+
+export interface ExportOverviewCardProps {
+  pendingSyncCount: number;
+}
+
+export default function ExportOverviewCard({ pendingSyncCount }: ExportOverviewCardProps): JSX.Element {
+  const formatItems = [
+    { label: 'Excel', icon: FileSpreadsheet },
+    { label: 'Markdown', icon: FileText },
+    { label: 'JSON', icon: FileJson },
+  ];
+
+  return (
+    <section className="w-full rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <h2 className="text-lg font-bold text-slate-950">导出概览</h2>
+      <p className="mt-1 text-sm text-slate-500">快速查看当前工作区的导出能力与同步状态。</p>
+      <div className="mt-5 space-y-4">
+        <div>
+          <div className="text-xs font-semibold text-slate-400">可导出格式</div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {formatItems.map((item) => {
+              const Icon = item.icon;
+              return (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-50 px-3 py-1.5 text-xs font-semibold text-[#2563EB]" key={item.label}>
+                  <Icon className="h-3.5 w-3.5" />
+                  {item.label}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="rounded-xl bg-[#F8FAFC] p-3">
+            <span className="text-slate-500">最近导出</span>
+            <div className="mt-1 font-semibold text-slate-900">暂无</div>
+          </div>
+          <div className="rounded-xl bg-[#F8FAFC] p-3">
+            <span className="text-slate-500">待同步记录</span>
+            <div className="mt-1 font-semibold text-slate-900">{pendingSyncCount}</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/components/HistoryTable.tsx
+++ b/src/pages/ai-workbench/history-export/components/HistoryTable.tsx
@@ -39,8 +39,8 @@ export default function HistoryTable({
   }, [page, totalPages]);
 
   return (
-    <section className="overflow-hidden rounded-xl border border-[#E5E7EB] bg-white shadow-sm">
-      <div className="flex items-center justify-between px-5 py-4">
+    <section className="w-full overflow-hidden rounded-xl border border-[#E5E7EB] bg-white shadow-sm">
+      <div className="flex flex-col gap-3 px-5 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-lg font-bold text-slate-950">生成历史</h2>
           <p className="mt-1 text-sm text-slate-500">展示本地保存的 AI 工作区历史，支持查看详情、继续编辑和删除。</p>
@@ -55,14 +55,17 @@ export default function HistoryTable({
           刷新
         </button>
       </div>
-      <table className="w-full text-left text-sm">
+      <div className="w-full overflow-x-auto">
+        <table className="min-w-[1080px] w-full text-left text-sm">
         <thead className="bg-[#F8FAFC] text-xs font-semibold uppercase tracking-wide text-slate-500">
           <tr>
             <th className="px-5 py-3">更新时间</th>
             <th className="px-5 py-3">工作区名称</th>
             <th className="px-5 py-3">需求名称</th>
             <th className="px-5 py-3">生成内容</th>
+            <th className="px-5 py-3">测试点数</th>
             <th className="px-5 py-3">用例数</th>
+            <th className="px-5 py-3">完成率</th>
             <th className="px-5 py-3">状态</th>
             <th className="px-5 py-3">操作</th>
           </tr>
@@ -74,7 +77,9 @@ export default function HistoryTable({
               <td className="px-5 py-4 font-semibold text-slate-900">{record.projectName}</td>
               <td className="px-5 py-4 text-slate-700">{record.requirementName}</td>
               <td className="max-w-xs px-5 py-4 text-slate-600">{record.generatedContent}</td>
+              <td className="px-5 py-4 font-semibold text-slate-900">{record.testPointCount}</td>
               <td className="px-5 py-4 font-semibold text-slate-900">{record.caseCount}</td>
+              <td className="px-5 py-4 font-semibold text-slate-900">{record.coverage}</td>
               <td className="px-5 py-4"><StatusTag status={record.status} /></td>
               <td className="px-5 py-4">
                 <div className="flex items-center gap-1">
@@ -93,20 +98,21 @@ export default function HistoryTable({
           ))}
           {!loading && records.length === 0 ? (
             <tr>
-              <td className="px-5 py-12 text-center text-sm text-slate-500" colSpan={7}>
+              <td className="px-5 py-12 text-center text-sm text-slate-500" colSpan={9}>
                 暂无本地 AI 工作区历史。生成用例后，记录会自动保存在这里。
               </td>
             </tr>
           ) : null}
           {loading ? (
             <tr>
-              <td className="px-5 py-12 text-center text-sm text-slate-500" colSpan={7}>
+              <td className="px-5 py-12 text-center text-sm text-slate-500" colSpan={9}>
                 正在加载本地历史记录...
               </td>
             </tr>
           ) : null}
         </tbody>
-      </table>
+        </table>
+      </div>
       <Pagination currentPage={safePage} pageSize={PAGE_SIZE} total={records.length} totalPages={totalPages} onPageChange={setPage} />
     </section>
   );

--- a/src/pages/ai-workbench/history-export/components/RecentExportList.tsx
+++ b/src/pages/ai-workbench/history-export/components/RecentExportList.tsx
@@ -8,16 +8,19 @@ export interface RecentExportListProps {
 
 export default function RecentExportList({ exports }: RecentExportListProps): JSX.Element {
   return (
-    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+    <section className="w-full rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
       <h2 className="text-lg font-bold text-slate-950">最近导出记录</h2>
       <div className="mt-4 space-y-3">
+        {exports.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-[#E5E7EB] py-8 text-center text-sm text-slate-500">暂无导出记录</div>
+        ) : null}
         {exports.map((item) => (
-          <div className="flex items-center justify-between rounded-xl border border-[#E5E7EB] p-3" key={item.id}>
-            <div>
-              <div className="font-semibold text-slate-900">{item.fileName}</div>
+          <div className="flex items-start justify-between gap-3 rounded-xl border border-[#E5E7EB] p-3" key={item.id}>
+            <div className="min-w-0">
+              <div className="truncate font-semibold text-slate-900" title={item.fileName}>{item.fileName}</div>
               <div className="mt-1 text-xs text-slate-500">{item.format} · {item.time} · {item.size}</div>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex shrink-0 items-center gap-2">
               <span className={`rounded-full px-2.5 py-1 text-xs font-semibold ${item.status === '完成' ? 'bg-emerald-50 text-emerald-700' : 'bg-orange-50 text-orange-700'}`}>{item.status}</span>
               <button className="rounded-lg border border-[#E5E7EB] p-2 text-slate-500 hover:text-[#2563EB]" type="button" aria-label={`下载 ${item.fileName}`}>
                 <Download className="h-4 w-4" />

--- a/src/pages/ai-workbench/history-export/components/StatCard.tsx
+++ b/src/pages/ai-workbench/history-export/components/StatCard.tsx
@@ -7,7 +7,7 @@ export interface StatCardProps {
 export default function StatCard({ item }: StatCardProps): JSX.Element {
   const Icon = item.icon;
   return (
-    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+    <section className="w-full rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
       <div className="flex items-start justify-between">
         <div>
           <p className="text-sm text-slate-500">{item.label}</p>

--- a/src/pages/ai-workbench/history-export/components/StatusTag.tsx
+++ b/src/pages/ai-workbench/history-export/components/StatusTag.tsx
@@ -2,13 +2,13 @@ import type { HistoryStatus } from '../types';
 
 const statusStyles: Record<HistoryStatus, string> = {
   success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-  processing: 'border-orange-200 bg-orange-50 text-orange-700',
+  draft: 'border-slate-200 bg-slate-50 text-slate-600',
   failed: 'border-red-200 bg-red-50 text-red-700',
 };
 
 const statusLabels: Record<HistoryStatus, string> = {
   success: '生成成功',
-  processing: '生成中',
+  draft: '草稿',
   failed: '生成失败',
 };
 

--- a/src/pages/ai-workbench/history-export/components/SyncPanel.tsx
+++ b/src/pages/ai-workbench/history-export/components/SyncPanel.tsx
@@ -7,21 +7,21 @@ export interface SyncPanelProps {
 
 export default function SyncPanel({ isSyncing, onSync }: SyncPanelProps): JSX.Element {
   return (
-    <section className="rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
-      <div className="flex items-start justify-between gap-4">
+    <section className="w-full rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-4">
         <div>
-          <h2 className="text-lg font-bold text-slate-950">同步用例</h2>
+          <h2 className="text-lg font-bold text-slate-950">同步到测试平台</h2>
           <p className="mt-1 text-sm text-slate-500">将已确认用例同步到测试管理平台，并保留同步日志。</p>
         </div>
-        <button className="inline-flex items-center gap-2 rounded-xl bg-[#2563EB] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-70" disabled={isSyncing} type="button" onClick={onSync}>
+        <button className="inline-flex w-fit items-center gap-2 rounded-xl bg-[#2563EB] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-70" disabled={isSyncing} type="button" onClick={onSync}>
           {isSyncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
           {isSyncing ? '同步中...' : '同步用例'}
         </button>
       </div>
-      <div className="mt-5 grid grid-cols-3 gap-3 text-sm">
-        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">目标空间</span><div className="mt-1 font-semibold text-slate-900">示例项目 / AI Case Space</div></div>
+      <div className="mt-5 space-y-3 text-sm">
+        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">测试平台</span><div className="mt-1 font-semibold text-slate-900">TestLink / TAPD / Jira</div></div>
         <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">待同步</span><div className="mt-1 font-semibold text-slate-900">128 条用例</div></div>
-        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">最近同步</span><div className="mt-1 font-semibold text-slate-900">2026-06-01 17:45</div></div>
+        <div className="rounded-xl bg-[#F8FAFC] p-3"><span className="text-slate-500">最近同步</span><div className="mt-1 font-semibold text-slate-900">暂无</div></div>
       </div>
     </section>
   );

--- a/src/pages/ai-workbench/history-export/components/VersionCompareCard.tsx
+++ b/src/pages/ai-workbench/history-export/components/VersionCompareCard.tsx
@@ -1,0 +1,48 @@
+import { GitCompareArrows } from 'lucide-react';
+
+export interface VersionCompareCardProps {
+  onCompare: () => void;
+}
+
+export default function VersionCompareCard({ onCompare }: VersionCompareCardProps): JSX.Element {
+  const changes = [
+    { label: '新增用例', value: '+28', className: 'text-emerald-600' },
+    { label: '删除用例', value: '-6', className: 'text-rose-600' },
+    { label: '变更模块', value: '3', className: 'text-[#2563EB]' },
+  ];
+
+  return (
+    <section className="w-full rounded-xl border border-[#E5E7EB] bg-white p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-slate-950">版本对比</h2>
+          <p className="mt-1 text-sm text-slate-500">聚合当前版本与上一版本的核心差异。</p>
+        </div>
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-[#2563EB]">
+          <GitCompareArrows className="h-5 w-5" />
+        </span>
+      </div>
+      <div className="mt-5 grid grid-cols-2 gap-3 text-sm">
+        <div className="rounded-xl bg-[#F8FAFC] p-3">
+          <span className="text-slate-500">当前版本</span>
+          <div className="mt-1 font-semibold text-slate-900">V1.2</div>
+        </div>
+        <div className="rounded-xl bg-[#F8FAFC] p-3">
+          <span className="text-slate-500">上一版本</span>
+          <div className="mt-1 font-semibold text-slate-900">V1.1</div>
+        </div>
+      </div>
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        {changes.map((item) => (
+          <div className="rounded-xl border border-[#E5E7EB] p-3 text-center" key={item.label}>
+            <div className={`text-xl font-bold ${item.className}`}>{item.value}</div>
+            <div className="mt-1 text-xs text-slate-500">{item.label}</div>
+          </div>
+        ))}
+      </div>
+      <button className="mt-5 w-full rounded-xl bg-[#2563EB] px-4 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-blue-600" type="button" onClick={onCompare}>
+        查看版本差异
+      </button>
+    </section>
+  );
+}

--- a/src/pages/ai-workbench/history-export/mock.ts
+++ b/src/pages/ai-workbench/history-export/mock.ts
@@ -1,4 +1,4 @@
-import { BarChart3, ClipboardCheck, FileJson, FileSpreadsheet, FileText, GitCompareArrows, ShieldCheck, TrendingUp } from 'lucide-react';
+import { BarChart3, ClipboardCheck, FileJson, FileSpreadsheet, FileText, GitCompareArrows, RefreshCw, ShieldCheck } from 'lucide-react';
 
 import type { ExportFormatOption, HistoryRecord, RecentExport, StatItem, VersionRecord } from './types';
 
@@ -10,34 +10,33 @@ export const statItems: StatItem[] = [
 ];
 
 export const historyRecords: HistoryRecord[] = [
-  { id: 'HIS-20260601-001', time: '2026-06-01 17:30', projectName: '示例项目', requirementName: '订单结算流程优化', generatedContent: '接口用例 / 异常场景 / 回归套件', caseCount: 128, status: 'success', owner: '张伟', duration: '2 分 18 秒', coverage: '96%' },
-  { id: 'HIS-20260531-014', time: '2026-05-31 15:12', projectName: '示例项目', requirementName: '会员权益配置后台', generatedContent: '功能用例 / 权限校验 / 边界值', caseCount: 86, status: 'processing', owner: '李娜', duration: '生成中', coverage: '91%' },
-  { id: 'HIS-20260530-009', time: '2026-05-30 10:45', projectName: '支付中台', requirementName: '支付渠道路由策略', generatedContent: '接口用例 / 幂等验证 / 监控校验', caseCount: 142, status: 'success', owner: '王强', duration: '3 分 02 秒', coverage: '98%' },
-  { id: 'HIS-20260529-021', time: '2026-05-29 19:04', projectName: '营销平台', requirementName: '优惠券批量发放', generatedContent: '批处理用例 / 风控规则 / 数据核对', caseCount: 74, status: 'failed', owner: '陈晨', duration: '58 秒', coverage: '73%' },
-  { id: 'HIS-20260528-018', time: '2026-05-28 14:26', projectName: '开放平台', requirementName: '开放 API 鉴权升级', generatedContent: '安全用例 / 签名校验 / 兼容性', caseCount: 118, status: 'success', owner: '周敏', duration: '2 分 46 秒', coverage: '95%' },
-  { id: 'HIS-20260527-016', time: '2026-05-27 11:18', projectName: '示例项目', requirementName: '客服工单智能分派', generatedContent: '流程用例 / SLA 校验 / 异常兜底', caseCount: 92, status: 'success', owner: '张伟', duration: '2 分 05 秒', coverage: '93%' },
-  { id: 'HIS-20260526-011', time: '2026-05-26 16:50', projectName: '数据资产', requirementName: '指标血缘追踪', generatedContent: '数据校验 / 权限矩阵 / 审计日志', caseCount: 64, status: 'processing', owner: '赵磊', duration: '生成中', coverage: '89%' },
-  { id: 'HIS-20260525-007', time: '2026-05-25 09:36', projectName: '移动端 App', requirementName: '登录态续期策略', generatedContent: '端到端用例 / 弱网场景 / 安全校验', caseCount: 105, status: 'success', owner: '孙悦', duration: '2 分 31 秒', coverage: '97%' },
+  { id: 'HIS-20260601-001', time: '2026-06-01 17:30', projectName: '示例项目', requirementName: '订单结算流程优化', generatedContent: '接口用例 / 异常场景 / 回归套件', testPointCount: 128, caseCount: 128, status: 'success', owner: '张伟', duration: '2 分 18 秒', coverage: '96%' },
+  { id: 'HIS-20260531-014', time: '2026-05-31 15:12', projectName: '示例项目', requirementName: '会员权益配置后台', generatedContent: '功能用例 / 权限校验 / 边界值', testPointCount: 86, caseCount: 86, status: 'draft', owner: '李娜', duration: '生成中', coverage: '91%' },
+  { id: 'HIS-20260530-009', time: '2026-05-30 10:45', projectName: '支付中台', requirementName: '支付渠道路由策略', generatedContent: '接口用例 / 幂等验证 / 监控校验', testPointCount: 142, caseCount: 142, status: 'success', owner: '王强', duration: '3 分 02 秒', coverage: '98%' },
+  { id: 'HIS-20260529-021', time: '2026-05-29 19:04', projectName: '营销平台', requirementName: '优惠券批量发放', generatedContent: '批处理用例 / 风控规则 / 数据核对', testPointCount: 74, caseCount: 74, status: 'failed', owner: '陈晨', duration: '58 秒', coverage: '73%' },
+  { id: 'HIS-20260528-018', time: '2026-05-28 14:26', projectName: '开放平台', requirementName: '开放 API 鉴权升级', generatedContent: '安全用例 / 签名校验 / 兼容性', testPointCount: 118, caseCount: 118, status: 'success', owner: '周敏', duration: '2 分 46 秒', coverage: '95%' },
+  { id: 'HIS-20260527-016', time: '2026-05-27 11:18', projectName: '示例项目', requirementName: '客服工单智能分派', generatedContent: '流程用例 / SLA 校验 / 异常兜底', testPointCount: 92, caseCount: 92, status: 'success', owner: '张伟', duration: '2 分 05 秒', coverage: '93%' },
+  { id: 'HIS-20260526-011', time: '2026-05-26 16:50', projectName: '数据资产', requirementName: '指标血缘追踪', generatedContent: '数据校验 / 权限矩阵 / 审计日志', testPointCount: 64, caseCount: 64, status: 'draft', owner: '赵磊', duration: '生成中', coverage: '89%' },
+  { id: 'HIS-20260525-007', time: '2026-05-25 09:36', projectName: '移动端 App', requirementName: '登录态续期策略', generatedContent: '端到端用例 / 弱网场景 / 安全校验', testPointCount: 105, caseCount: 105, status: 'success', owner: '孙悦', duration: '2 分 31 秒', coverage: '97%' },
 ];
 
 export const versionRecords: VersionRecord[] = [
-  { id: 'VER-12', version: 'V1.2', title: '补充异常断言与自动化脚本映射', time: '2026-06-01 17:30', author: '张伟', summary: '当前版本：新增支付失败、库存回滚、重试补偿等高优先级用例。', isCurrent: true },
-  { id: 'VER-11', version: 'V1.1', title: '完善核心链路与权限边界', time: '2026-05-30 18:20', author: '李娜', summary: '根据评审意见补充管理员、普通用户、访客三类权限矩阵。', isCurrent: false },
-  { id: 'VER-10', version: 'V1.0', title: '首次生成需求测试用例集', time: '2026-05-28 10:00', author: 'AI Copilot', summary: '基于需求原文生成冒烟、功能、接口、异常与回归用例。', isCurrent: false },
+  { id: 'VER-12', version: 'V1.2', title: '优化覆盖率', time: '2026-06-01 17:30', author: '张伟', summary: '新增 6 条用例，删除 2 条重复用例，覆盖率持续优化。', isCurrent: true },
+  { id: 'VER-11', version: 'V1.1', title: '补充异常场景', time: '2026-05-30 18:20', author: '李娜', summary: '新增 6 条用例，补充异常流程、边界输入和权限兜底。', isCurrent: false },
+  { id: 'VER-10', version: 'V1.0', title: '初始生成', time: '2026-05-28 10:00', author: 'AI Copilot', summary: '生成 10 条用例，覆盖核心业务主链路。', isCurrent: false },
 ];
 
 export const exportFormats: ExportFormatOption[] = [
-  { format: 'Excel', title: '导出 Excel', description: '适合导入测试管理平台，包含步骤、预期与优先级。', icon: FileSpreadsheet },
-  { format: 'Markdown', title: '导出 Markdown', description: '适合评审纪要、知识库和研发协作文档沉淀。', icon: FileText },
-  { format: 'JSON', title: '导出 JSON', description: '适合自动化流水线、接口平台和二次开发消费。', icon: FileJson },
-  { format: 'PDF', title: '导出 PDF', description: '适合归档、外部审阅和测试交付报告输出。', icon: TrendingUp },
+  { format: 'Excel', title: '导出 Excel', description: '导出为 Excel 文件，便于筛选、评审和执行。', icon: FileSpreadsheet },
+  { format: 'Markdown', title: '导出 Markdown', description: '导出为 Markdown 文档，便于沉淀到 Wiki。', icon: FileText },
+  { format: 'JSON', title: '导出 JSON', description: '导出为 JSON 数据，便于平台接口集成。', icon: FileJson },
+  { format: '测试平台同步', title: '立即同步', description: '同步到 TAPD / Jira / 内部测试平台。', icon: RefreshCw },
 ];
 
 export const recentExports: RecentExport[] = [
-  { id: 'EXP-001', fileName: '订单结算流程优化_用例集.xlsx', format: 'Excel', time: '2026-06-01 17:42', size: '2.4 MB', status: '完成' },
-  { id: 'EXP-002', fileName: '会员权益配置后台_评审版.md', format: 'Markdown', time: '2026-05-31 15:40', size: '486 KB', status: '完成' },
-  { id: 'EXP-003', fileName: '支付渠道路由策略_cases.json', format: 'JSON', time: '2026-05-30 11:04', size: '918 KB', status: '完成' },
-  { id: 'EXP-004', fileName: '开放API鉴权升级_交付报告.pdf', format: 'PDF', time: '2026-05-28 16:02', size: '5.8 MB', status: '处理中' },
+  { id: 'EXP-001', fileName: '用户下单流程需求文档.xlsx', format: 'Excel', time: '2026-06-01 17:42', size: '2.4 MB', status: '完成' },
+  { id: 'EXP-002', fileName: '风控规则引擎需求说明.md', format: 'Markdown', time: '2026-05-31 15:40', size: '486 KB', status: '完成' },
+  { id: 'EXP-003', fileName: '内容发布与审核需求.json', format: 'JSON', time: '2026-05-30 11:04', size: '918 KB', status: '完成' },
 ];
 
 export const diffSummary = [

--- a/src/pages/ai-workbench/history-export/types.ts
+++ b/src/pages/ai-workbench/history-export/types.ts
@@ -1,8 +1,8 @@
 import type { LucideIcon } from 'lucide-react';
 
-export type HistoryStatus = 'success' | 'processing' | 'failed';
+export type HistoryStatus = 'success' | 'draft' | 'failed';
 export type WorkspaceTab = 'history' | 'versions' | 'exports';
-export type ExportFormat = 'Excel' | 'Markdown' | 'JSON' | 'PDF';
+export type ExportFormat = 'Excel' | 'Markdown' | 'JSON' | '测试平台同步';
 
 export interface HistoryRecord {
   id: string;
@@ -10,6 +10,7 @@ export interface HistoryRecord {
   projectName: string;
   requirementName: string;
   generatedContent: string;
+  testPointCount: number;
   caseCount: number;
   status: HistoryStatus;
   owner: string;


### PR DESCRIPTION
### Motivation
- 解决宽屏下页面左右与下方出现大片空白的问题，使主内容区域可用宽度自适应并保留侧边菜单与顶部导航不变。 
- 将页面改为左主内容 + 右侧辅助信息的两栏布局，补充导出中心、最近导出、版本对比与同步面板，避免底部空白区。 

### Description
- 将页面容器从固定宽度/居中（`mx-auto` / `max-w-[1480px]`）替换为自适应容器 `w-full min-w-0 p-6` 并使用响应式栅格 `2xl:grid-cols-[minmax(0,1fr)_360px]` 来实现主内容 + 360px 侧栏布局（文件：`AiWorkbenchHistoryExport.tsx`）。
- 调整 App 布局主区域以支持 shrink/grow 并设置背景：在 `Layout` 将滚动容器改为 `h-full min-w-0 flex-1 overflow-y-auto bg-slate-50`，确保主区不会被固定宽度约束（文件：`src/components/Layout.tsx`）。
- 扩展统计卡、Tab、表格与导出中心为宽屏自适应：将统计卡改为 `grid-cols-1 md:grid-cols-2 xl:grid-cols-4`，Tab 与卡片使用 `w-full` 样式，导出按钮改为响应式网格（文件：`history-export` 下的多个组件）。
- 将历史表格扩展为占满左侧主内容，增加横向安全滚动容器并增加列：`测试点数`、`用例数`、`完成率` 等（`HistoryTable.tsx`），并把表格最小宽度设为 `min-w-[1080px]` 防止窄列压缩导致布局错位。
- 新增与填充右侧面板组件：`ExportOverviewCard`、`VersionCompareCard`，并完善 `RecentExportList`、`SyncPanel` 以填充右侧空白（新增/修改的组件在 `src/pages/ai-workbench/history-export/components/`）。
- 更新导出选项与 mock 数据以支持 `测试平台同步` 选项，调整状态类型将 `processing` 替换为 `draft`（显示为“草稿”），并在类型定义中加入 `testPointCount` 字段（文件：`mock.ts`、`types.ts`、`StatusTag.tsx`）。

### Testing
- 运行类型检查：`npx tsc --noEmit -p tsconfig.json`，执行成功。 
- 后端类型检查：`npx tsc --noEmit -p tsconfig.server.json`，执行成功。 
- 前端生产构建：`npm run build`（Vite），构建成功（包含若干构建体积警告但不影响产物）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b6d7b1ec8332aaabe57759728eb2)