### PR TITLE
Enable AI workbench shortcut navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,13 +33,13 @@ import { User } from "lucide-react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 
-const AI_WORKBENCH_CASE_GENERATION_ROUTE = "/ai-workbench/test-cases";
+const AI_WORKBENCH_CASE_GENERATION_ROUTES = ["/ai-workbench/test-cases", "/ai-workbench/use-case-generate"];
+const AI_WORKBENCH_CASE_GENERATION_ROUTE = AI_WORKBENCH_CASE_GENERATION_ROUTES[0];
 
 function isAiWorkbenchCaseGenerationRoute(location: string): boolean {
   const normalized = location.endsWith('/') ? location.slice(0, -1) : location;
-  return (
-    normalized === AI_WORKBENCH_CASE_GENERATION_ROUTE ||
-    normalized.startsWith(`${AI_WORKBENCH_CASE_GENERATION_ROUTE}?`)
+  return AI_WORKBENCH_CASE_GENERATION_ROUTES.some((route) =>
+    normalized === route || normalized.startsWith(`${route}?`)
   );
 }
 
@@ -180,6 +180,9 @@ function Router() {
         <Route path="/ai-workbench/test-cases">
           {null}
         </Route>
+        <Route path="/ai-workbench/use-case-generate">
+          {null}
+        </Route>
         <Route path="/ai-workbench/home">
           <ProtectedLayout>
             <AiWorkbenchOverview />
@@ -189,6 +192,11 @@ function Router() {
           <Redirect to="/ai-workbench/home" />
         </Route>
         <Route path="/ai-workbench/requirements">
+          <ProtectedLayout>
+            <AiWorkbenchRequirementInput />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/requirement-parse">
           <ProtectedLayout>
             <AiWorkbenchRequirementInput />
           </ProtectedLayout>
@@ -203,7 +211,17 @@ function Router() {
             <AiWorkbenchQualityCoverage />
           </ProtectedLayout>
         </Route>
+        <Route path="/ai-workbench/quality-check">
+          <ProtectedLayout>
+            <AiWorkbenchQualityCoverage />
+          </ProtectedLayout>
+        </Route>
         <Route path="/ai-workbench/exports">
+          <ProtectedLayout>
+            <AiWorkbenchHistoryExport />
+          </ProtectedLayout>
+        </Route>
+        <Route path="/ai-workbench/export-records">
           <ProtectedLayout>
             <AiWorkbenchHistoryExport />
           </ProtectedLayout>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -59,11 +59,11 @@ const navItems: NavItem[] = [
     label: "AI 工作台",
     children: [
       { label: "首页", href: "/ai-workbench/home", icon: <BrainCircuit className="h-4 w-4" /> },
-      { label: "需求解析", href: "/ai-workbench/requirements", icon: <FileInput className="h-4 w-4" /> },
+      { label: "需求解析", href: "/ai-workbench/requirement-parse", icon: <FileInput className="h-4 w-4" /> },
       { label: "测试点", href: "/ai-workbench/test-points", icon: <ClipboardList className="h-4 w-4" /> },
-      { label: "用例生成", href: "/ai-workbench/test-cases", icon: <FileText className="h-4 w-4" /> },
-      { label: "质量检查", href: "/ai-workbench/quality", icon: <ShieldCheck className="h-4 w-4" /> },
-      { label: "导出记录", href: "/ai-workbench/exports", icon: <BookOpen className="h-4 w-4" /> },
+      { label: "用例生成", href: "/ai-workbench/use-case-generate", icon: <FileText className="h-4 w-4" /> },
+      { label: "质量检查", href: "/ai-workbench/quality-check", icon: <ShieldCheck className="h-4 w-4" /> },
+      { label: "导出记录", href: "/ai-workbench/export-records", icon: <BookOpen className="h-4 w-4" /> },
     ],
   },
   { icon: <Boxes className="h-5 w-5" />, label: "任务管理", href: "/tasks" },
@@ -74,13 +74,29 @@ const navItems: NavItem[] = [
 // ----------------------------------------------------------------
 // Utility: check if a nav item is active
 // ----------------------------------------------------------------
+const navPathAliases: Record<string, string> = {
+  "/ai-workbench/requirements": "/ai-workbench/requirement-parse",
+  "/ai-workbench/requirement-input": "/ai-workbench/requirement-parse",
+  "/ai-workbench/test-cases": "/ai-workbench/use-case-generate",
+  "/ai-workbench/case-generation": "/ai-workbench/use-case-generate",
+  "/ai-workbench/quality": "/ai-workbench/quality-check",
+  "/ai-workbench/quality-coverage": "/ai-workbench/quality-check",
+  "/ai-workbench/exports": "/ai-workbench/export-records",
+  "/ai-workbench/history-export": "/ai-workbench/export-records",
+};
+
 function normalizePath(path: string): string {
   return path.split(/[?#]/)[0] || "/";
 }
 
+function normalizeNavPath(path: string): string {
+  const normalized = normalizePath(path);
+  return navPathAliases[normalized] ?? normalized;
+}
+
 function isPathActive(location: string, href: string): boolean {
-  const currentPath = normalizePath(location);
-  const targetPath = normalizePath(href);
+  const currentPath = normalizeNavPath(location);
+  const targetPath = normalizeNavPath(href);
 
   return currentPath === targetPath || currentPath.startsWith(`${targetPath}/`);
 }

--- a/src/pages/ai-workbench/home/CoverageOverviewCard.tsx
+++ b/src/pages/ai-workbench/home/CoverageOverviewCard.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight, Info } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 const legendItems = [
   { label: '已覆盖', value: '312 (78%)', dotClassName: 'bg-[#2563EB]' },
@@ -7,8 +8,10 @@ const legendItems = [
 ];
 
 export default function CoverageOverviewCard(): JSX.Element {
+  const [, navigate] = useLocation();
+
   const handleViewCoverage = (): void => {
-    console.log('查看覆盖率详情');
+    navigate('/ai-workbench/quality-check');
   };
 
   return (
@@ -44,7 +47,7 @@ export default function CoverageOverviewCard(): JSX.Element {
         <span className="text-[#6B7280]">更新时间：2024-05-20 14:30</span>
       </div>
 
-      <button type="button" onClick={handleViewCoverage} className="mx-auto mt-4 flex items-center gap-1 text-sm font-medium text-[#2563EB] hover:underline">
+      <button type="button" aria-label="跳转到质量检查" onClick={handleViewCoverage} className="mx-auto mt-4 flex cursor-pointer items-center gap-1 text-sm font-medium text-[#2563EB] transition hover:text-[#1D4ED8] hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2">
         查看覆盖率详情 <ChevronRight className="h-4 w-4" />
       </button>
     </section>

--- a/src/pages/ai-workbench/home/QuickStartSteps.tsx
+++ b/src/pages/ai-workbench/home/QuickStartSteps.tsx
@@ -1,4 +1,5 @@
 import { ChevronRight } from 'lucide-react';
+import { useLocation } from 'wouter';
 
 import type { QuickStartStep } from '@/pages/ai-workbench/home/types';
 
@@ -7,9 +8,7 @@ interface QuickStartStepsProps {
 }
 
 export default function QuickStartSteps({ steps }: QuickStartStepsProps): JSX.Element {
-  const handleStepClick = (stepName: string): void => {
-    console.log(`快速开始步骤：${stepName}`);
-  };
+  const [, navigate] = useLocation();
 
   return (
     <section className="rounded-2xl border border-[#E5E7EB] bg-white p-5 shadow-[0_8px_20px_rgba(15,23,42,0.04)]">
@@ -21,21 +20,22 @@ export default function QuickStartSteps({ steps }: QuickStartStepsProps): JSX.El
         {steps.map((step, index) => {
           const Icon = step.icon;
           return (
-            <div key={step.title} className="relative">
+            <div key={step.title} className="group relative">
               <button
                 type="button"
-                onClick={() => handleStepClick(step.title)}
-                className="flex min-h-[132px] w-full flex-col items-center rounded-xl border border-[#E5E7EB] bg-white px-3 py-4 text-center transition hover:border-blue-200 hover:shadow-md"
+                aria-label={step.ariaLabel}
+                onClick={() => navigate(step.path)}
+                className="flex min-h-[132px] w-full cursor-pointer flex-col items-center rounded-xl border border-[#E5E7EB] bg-white px-3 py-4 text-center transition hover:border-blue-300 hover:bg-blue-50 hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
               >
                 <span className="absolute left-3 top-3 flex h-6 w-6 items-center justify-center rounded-full bg-[#2563EB] text-xs font-bold text-white">
                   {index + 1}
                 </span>
-                <Icon className="mt-4 h-8 w-8 text-[#2563EB]" />
+                <Icon className="mt-4 h-8 w-8 text-[#2563EB] transition group-hover:text-[#1D4ED8]" />
                 <h3 className="mt-3 text-sm font-bold text-[#111827]">{step.title}</h3>
                 <p className="mt-2 text-xs leading-5 text-[#6B7280]">{step.description}</p>
               </button>
               {index < steps.length - 1 ? (
-                <ChevronRight className="absolute -right-3 top-1/2 z-10 h-5 w-5 -translate-y-1/2 rounded-full bg-[#F8FAFC] text-[#6B7280]" />
+                <ChevronRight className="absolute -right-3 top-1/2 z-10 h-5 w-5 -translate-y-1/2 rounded-full bg-[#F8FAFC] text-[#6B7280] transition group-hover:text-[#2563EB]" />
               ) : null}
             </div>
           );

--- a/src/pages/ai-workbench/home/mock.ts
+++ b/src/pages/ai-workbench/home/mock.ts
@@ -22,11 +22,41 @@ export const stats: StatItem[] = [
 ];
 
 export const quickStartSteps: QuickStartStep[] = [
-  { title: '上传需求', description: '支持 Word、PDF、TXT 等格式', icon: UploadCloud },
-  { title: '智能解析', description: 'AI 解析需求内容，提取关键信息', icon: FileSearch },
-  { title: '生成测试点', description: '识别测试点，覆盖功能与非功能需求', icon: Target },
-  { title: '生成测试用例', description: 'AI 生成详细测试用例，支持编辑优化', icon: ListChecks },
-  { title: '导出 Excel', description: '一键导出测试用例，便于执行与管理', icon: FileSpreadsheet },
+  {
+    title: '上传需求',
+    description: '支持 Word、PDF、TXT 等格式',
+    icon: UploadCloud,
+    path: '/ai-workbench/requirement-parse',
+    ariaLabel: '跳转到需求解析',
+  },
+  {
+    title: '智能解析',
+    description: 'AI 解析需求内容，提取关键信息',
+    icon: FileSearch,
+    path: '/ai-workbench/test-points',
+    ariaLabel: '跳转到测试点',
+  },
+  {
+    title: '生成测试点',
+    description: '识别测试点，覆盖功能与非功能需求',
+    icon: Target,
+    path: '/ai-workbench/use-case-generate',
+    ariaLabel: '跳转到用例生成',
+  },
+  {
+    title: '生成测试用例',
+    description: 'AI 生成详细测试用例，支持编辑优化',
+    icon: ListChecks,
+    path: '/ai-workbench/use-case-generate',
+    ariaLabel: '跳转到用例生成',
+  },
+  {
+    title: '导出 Excel',
+    description: '一键导出测试用例，便于执行与管理',
+    icon: FileSpreadsheet,
+    path: '/ai-workbench/export-records',
+    ariaLabel: '跳转到导出记录',
+  },
 ];
 
 export const recentProjects: RecentProject[] = [

--- a/src/pages/ai-workbench/home/types.ts
+++ b/src/pages/ai-workbench/home/types.ts
@@ -12,6 +12,8 @@ export interface QuickStartStep {
   title: string;
   description: string;
   icon: LucideIcon;
+  path: string;
+  ariaLabel: string;
 }
 
 export type ProjectStatus = '已完成' | '解析完成' | '用例生成中' | '测试点生成中';


### PR DESCRIPTION
### Motivation
- Make the AI 工作台首页的“快速开始”卡片和“需求覆盖概览”CTA interactive so users can jump directly to the relevant AI 工作台 pages. 
- Ensure left-sidebar selection stays in sync with these shortcut navigations and supports both legacy and new route aliases. 

### Description
- Added `path` and `ariaLabel` to `QuickStartStep` and updated `quickStartSteps` in `src/pages/ai-workbench/home/mock.ts` with the target routes and accessibility labels. 
- Implemented click navigation in `QuickStartSteps.tsx` using the project `wouter` `useLocation()` navigate and added hover/focus/cursor and icon/arrow highlight styles for visible interactive affordance. 
- Wired the coverage CTA in `CoverageOverviewCard.tsx` to navigate to `/ai-workbench/quality-check` and added `aria-label` and focus styles. 
- Registered the suggested routes (`/ai-workbench/requirement-parse`, `/ai-workbench/use-case-generate`, `/ai-workbench/quality-check`, `/ai-workbench/export-records`) in `src/App.tsx` and made the keep-alive case-generation layer recognize both the old and new generation routes. 
- Updated `src/components/Sidebar.tsx` to use the new AI 工作台 child `href`s and introduced `navPathAliases` + `normalizeNavPath` so active matching treats legacy and new paths as equivalent, keeping the sidebar highlight in sync after navigation. 

### Testing
- Type check: `npx tsc --noEmit -p tsconfig.json` ran successfully. 
- Production build: `npm run build` (Vite) completed successfully with build warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26b6fc4f4c833296e394b37413fdd4)