### PR TITLE
Fix requirement cleaning behavior, UI text, cancelled task status, and add tests

### DIFF
--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -21,12 +21,12 @@ import {
 const textFileTypes = new Set(["markdown", "text", "excel"]);
 
 interface ParseAnalysisPanelProps {
-  wordCount: number;
+  characterCount: number;
 }
 
-function ParseAnalysisPanel({ wordCount }: ParseAnalysisPanelProps) {
+function ParseAnalysisPanel({ characterCount }: ParseAnalysisPanelProps) {
   const summaryItems = [
-    { label: "文档字数", value: wordCount },
+    { label: "文档字符数", value: characterCount },
     { label: "识别模块", value: 0 },
     { label: "需求疑问", value: 0 },
     { label: "风险点", value: 0 },
@@ -124,7 +124,7 @@ function RequirementInputParsePage() {
   });
 
   const cleanedText = useMemo(() => cleanRequirementText(rawText, rules), [rawText, rules]);
-  const wordCount = cleanedText.length;
+  const characterCount = cleanedText.length;
 
   useEffect(() => {
     const nextProgress = Math.min(100, 35 + (files.length > 0 ? 15 : 0) + (rawText.trim() ? 25 : 0) + (cleanedText.trim() ? 25 : 0));
@@ -232,12 +232,12 @@ function RequirementInputParsePage() {
             <RequirementConfigForm config={config} onChange={setConfig} />
             <RequirementTextEditor value={rawText} onChange={setRawText} />
             <ParseProgressSteps progress={progress} />
-            <RequirementContentCompare rawText={rawText} cleanedText={cleanedText} wordCount={wordCount} />
+            <RequirementContentCompare rawText={rawText} cleanedText={cleanedText} wordCount={characterCount} />
           </section>
 
           {/* Analysis column */}
           <aside className="w-full space-y-4 xl:col-span-2 2xl:col-span-1">
-            <ParseAnalysisPanel wordCount={wordCount} />
+            <ParseAnalysisPanel characterCount={characterCount} />
           </aside>
         </div>
       </main>

--- a/src/pages/cases/components/RequirementContentCompare.tsx
+++ b/src/pages/cases/components/RequirementContentCompare.tsx
@@ -22,7 +22,7 @@ function RequirementContentCompare({ rawText, cleanedText, wordCount }: Requirem
               原始 {rawLineCount} 行
             </Badge>
             <Badge className="bg-[#39E079]/10 text-[#2ba85a] dark:bg-[#39E079]/15 dark:text-[#39E079]">
-              清洗 {cleanLineCount} 行
+              清洗后 {cleanLineCount} 行
             </Badge>
           </div>
         </div>

--- a/src/pages/cases/requirementInputUtils.ts
+++ b/src/pages/cases/requirementInputUtils.ts
@@ -91,7 +91,7 @@ export function cleanRequirementText(
       return normalizeVisibleSpacing(line);
     }
 
-    return line.trim();
+    return line;
   });
 
   if (mergedOptions.removeEmptyLines) {
@@ -99,7 +99,8 @@ export function cleanRequirementText(
   }
 
   if (!mergedOptions.mergeBrokenLines) {
-    return lines.join("\n").trim();
+    const cleanedText = lines.join("\n");
+    return mergedOptions.trimExtraSpaces ? cleanedText.trim() : cleanedText;
   }
 
   const mergedLines: string[] = [];
@@ -115,7 +116,8 @@ export function cleanRequirementText(
     mergedLines.push(line);
   });
 
-  return mergedLines.join("\n").trim();
+  const cleanedText = mergedLines.join("\n");
+  return mergedOptions.trimExtraSpaces ? cleanedText.trim() : cleanedText;
 }
 
 export function getFileType(fileName: string): RequirementFileType {

--- a/src/pages/tasks/components/taskPageConfig.ts
+++ b/src/pages/tasks/components/taskPageConfig.ts
@@ -77,6 +77,7 @@ export const TASK_STATUS_SEMANTIC = {
   pending: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300',
   paused: 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300',
   failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+  cancelled: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
   draft: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
 } as const;
 
@@ -117,6 +118,7 @@ export const getTaskSemanticStatus = (task: Task): { key: TaskSemanticStatus; la
   }
   if (task.status === 'paused') return { key: 'paused', label: '暂停' };
   if (latest?.status === 'failed') return { key: 'failed', label: '失败' };
+  if (latest?.status === 'cancelled') return { key: 'cancelled', label: '已取消' };
   // 从未执行过时（latest 为空），显示"空闲"而非"成功"，避免语义误导
   if (!latest) return { key: 'draft', label: '空闲' };
   return { key: 'success', label: '成功' };

--- a/test_case/frontend/pages/requirementInputUtils.test.ts
+++ b/test_case/frontend/pages/requirementInputUtils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { cleanRequirementText, getFileType } from '@/pages/cases/requirementInputUtils';
+
+describe('requirementInputUtils - cleanRequirementText', () => {
+  it('保留用户显式关闭空格清洗时的行内空白', () => {
+    const input = '  用户   可以\t创建　订单  ';
+
+    const result = cleanRequirementText(input, {
+      mergeBrokenLines: false,
+      trimExtraSpaces: false,
+    });
+
+    expect(result).toBe(input);
+  });
+
+  it('清洗空行、多余空格和不可见字符', () => {
+    const result = cleanRequirementText('  登录\u200B后   展示首页\n\n  支持　退出  ', {
+      mergeBrokenLines: false,
+    });
+
+    expect(result).toBe('登录后 展示首页\n支持 退出');
+  });
+
+  it('合并异常换行但保留 Markdown 表格结构', () => {
+    const markdownTable = '| 字段 | 说明 |\n| --- | --- |\n| name | 用户名称 |';
+    const result = cleanRequirementText(`会员资料字段\n${markdownTable}\n字段需要支持编辑`);
+
+    expect(result).toBe(`会员资料字段\n${markdownTable}\n字段需要支持编辑`);
+  });
+});
+
+describe('requirementInputUtils - getFileType', () => {
+  it('识别常用需求附件类型', () => {
+    expect(getFileType('需求说明.markdown')).toBe('markdown');
+    expect(getFileType('接口清单.CSV')).toBe('excel');
+    expect(getFileType('补充说明.text')).toBe('text');
+    expect(getFileType('压缩包.zip')).toBe('unknown');
+  });
+});

--- a/test_case/frontend/pages/tasks-utils.test.ts
+++ b/test_case/frontend/pages/tasks-utils.test.ts
@@ -79,6 +79,14 @@ describe('taskPageConfig - getTaskSemanticStatus', () => {
 
     expect(result).toEqual({ key: 'pending', label: '排队中' });
   });
+
+  it('cancelled 执行应显示“已取消”，避免被兜底为成功', () => {
+    const result = getTaskSemanticStatus(
+      makeTask({ recentExecutions: [makeExecution({ status: 'cancelled' })] })
+    );
+
+    expect(result).toEqual({ key: 'cancelled', label: '已取消' });
+  });
 });
 
 describe('taskPageConfig - getTaskSuccessRate', () => {


### PR DESCRIPTION
### Motivation
- Avoid surprising whitespace removal when users disable extra-space trimming in requirement cleaning. 
- Ensure task status semantics show `cancelled` instead of falling back to `success`. 
- Make UI labels consistent with the data being shown (character count vs word count) and clarify the cleaned-line badge. 
- Improve test coverage for the requirement cleaning utilities and the cancelled task status behavior. 

### Description
- Update `cleanRequirementText` in `src/pages/cases/requirementInputUtils.ts` to preserve line-leading/trailing whitespace when `trimExtraSpaces` is disabled and apply trimming only when requested, and to avoid unconditional final `trim()` when merging lines. 
- Rename and align parse metrics in `RequirementInputParsePage.tsx` from `wordCount` to `characterCount` and use `cleanedText.length` with the label changed to "文档字符数". 
- Change the comparison badge in `RequirementContentCompare.tsx` from "清洗 X 行" to "清洗后 X 行" for clearer wording. 
- Add `cancelled` visual semantic and mapping in `src/pages/tasks/components/taskPageConfig.ts` so a latest execution with status `cancelled` returns `{ key: 'cancelled', label: '已取消' }`. 
- Add unit tests: `test_case/frontend/pages/requirementInputUtils.test.ts` covering whitespace/trimming, markdown-table preservation and file type detection, and extend `test_case/frontend/pages/tasks-utils.test.ts` with a `cancelled` execution case. 

### Testing
- Ran targeted frontend tests with `npx vitest run test_case/frontend/pages/requirementInputUtils.test.ts test_case/frontend/pages/tasks-utils.test.ts` and both files passed (2 test files, all tests green). 
- Ran full test suite with `npx vitest run` and observed all tests passing (all test files and assertions succeeded). 
- Performed TypeScript checks with `npx tsc --noEmit -p tsconfig.json` and `npx tsc --noEmit -p tsconfig.server.json`, both completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a278806dd048332a86b06b303d01991)