### PR TITLE
Fix early daily summary scheduling

### DIFF
--- a/server/services/DailySummaryScheduler.ts
+++ b/server/services/DailySummaryScheduler.ts
@@ -55,20 +55,33 @@ export class DailySummaryScheduler {
   }
 
   /**
+   * 获取下一次每日汇总执行时间。
+   * 如果服务在当天 00:05 之前启动，应调度到当天 00:05，避免跳过一次 T-1 汇总。
+   */
+  private getNextExecutionTime(now: Date = new Date()): Date {
+    const nextRun = new Date(now);
+    nextRun.setHours(0, 5, 0, 0);
+
+    if (now.getTime() >= nextRun.getTime()) {
+      nextRun.setDate(nextRun.getDate() + 1);
+    }
+
+    return nextRun;
+  }
+
+  /**
    * 计算并调度下一次执行
    */
   private scheduleNextExecution(): void {
     const now = new Date();
-    const tomorrow = new Date(now);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 5, 0, 0); // 设置为明天 00:05
+    const nextRun = this.getNextExecutionTime(now);
 
-    const timeUntilNextRun = tomorrow.getTime() - now.getTime();
+    const timeUntilNextRun = nextRun.getTime() - now.getTime();
 
     logger.debug('Scheduling next daily summary execution', {
       event: LOG_EVENTS.SCHEDULER_DAILY_SUMMARY_STARTED,
       currentTime: now.toISOString(),
-      nextRunTime: tomorrow.toISOString(),
+      nextRunTime: nextRun.toISOString(),
       delayMs: timeUntilNextRun,
     }, LOG_CONTEXTS.SCHEDULER);
 
@@ -161,12 +174,7 @@ export class DailySummaryScheduler {
     };
 
     if (this.isRunning) {
-      // 计算下一次执行时间
-      const now = new Date();
-      const tomorrow = new Date(now);
-      tomorrow.setDate(tomorrow.getDate() + 1);
-      tomorrow.setHours(0, 5, 0, 0);
-      status.nextExecution = tomorrow.toISOString();
+      status.nextExecution = this.getNextExecutionTime().toISOString();
     }
 
     return status;


### PR DESCRIPTION
### Motivation
- The daily summary scheduler could skip generating a T-1 summary when the service starts before 00:05 because it always scheduled the next run for tomorrow instead of the current day's 00:05 window.

### Description
- Added `getNextExecutionTime(now?: Date): Date` to compute the correct next run time (today 00:05 if before that, otherwise tomorrow 00:05). 
- Updated `scheduleNextExecution` to reuse `getNextExecutionTime` and log the actual `nextRunTime` used for the timer. 
- Updated `getStatus()` to return a `nextExecution` value from the same `getNextExecutionTime` logic so status reporting matches the actual schedule (modified file: `server/services/DailySummaryScheduler.ts`).

### Testing
- Type-check: ran `npx tsc --noEmit -p tsconfig.server.json` with success. 
- Unit tests: ran `npx vitest run` and `npx vitest run test_case/backend/services/TaskSchedulerCron.test.ts` and all tests passed (`366` tests total). 
- Build: ran `npm run build` (frontend) and `npm run server:build` (backend) and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a45b225188332ae6982ea8fc97634)