### PR TITLE
feat(requirements): 需求输入解析附件上传与数据库落地

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,9 +40,12 @@
     "glob": "^13.0.0",
     "jsonwebtoken": "^9.0.3",
     "lucide-react": "^0.312.0",
+    "mammoth": "^1.11.0",
+    "multer": "^2.0.2",
     "mysql2": "^3.16.1",
     "node-fetch": "^3.3.2",
     "nodemailer": "^7.0.12",
+    "pdf-parse": "^2.4.5",
     "qs": "^6.14.1",
     "react": "^18.2.0",
     "react-day-picker": "^9.14.0",
@@ -57,7 +60,8 @@
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
     "typeorm": "^0.3.28",
-    "wouter": "^2.12.1"
+    "wouter": "^2.12.1",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
@@ -66,6 +70,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/multer": "^2.0.0",
     "@types/node": "^20.11.5",
     "@types/nodemailer": "^7.0.4",
     "@types/react": "^18.2.48",

--- a/server/database/requirement-input-parse-schema.sql
+++ b/server/database/requirement-input-parse-schema.sql
@@ -1,0 +1,94 @@
+-- 需求输入与解析页面数据库结构
+-- 适用范围：附件上传、文本清洗、AI 结构化解析、解析结果回溯
+-- 注意：生产环境执行前请先备份数据库。
+
+CREATE TABLE IF NOT EXISTS Auto_RequirementParseSession (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '解析任务ID',
+  session_key VARCHAR(64) NOT NULL COMMENT '前端会话唯一标识',
+  project_id VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '项目ID或业务空间ID',
+  title VARCHAR(255) NULL COMMENT '需求标题',
+  product_line VARCHAR(128) NULL COMMENT '产品线',
+  priority VARCHAR(32) NOT NULL DEFAULT 'P1' COMMENT '默认优先级',
+  raw_text LONGTEXT NULL COMMENT '页面手工输入与附件合并前文本',
+  cleaned_text LONGTEXT NULL COMMENT '清洗后文本',
+  clean_config JSON NULL COMMENT '清洗规则配置',
+  parse_options JSON NULL COMMENT 'AI解析选项，例如摘要、风险扫描、用例建议',
+  parse_status VARCHAR(32) NOT NULL DEFAULT 'draft' COMMENT 'draft/parsing/success/failed',
+  parse_error TEXT NULL COMMENT '解析失败原因',
+  created_by BIGINT NULL COMMENT '创建人ID，暂允许为空',
+  updated_by BIGINT NULL COMMENT '更新人ID，暂允许为空',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_requirement_parse_session_key (session_key),
+  KEY idx_requirement_parse_project_id (project_id),
+  KEY idx_requirement_parse_status (parse_status),
+  KEY idx_requirement_parse_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='需求输入与解析页面任务表';
+
+CREATE TABLE IF NOT EXISTS Auto_RequirementFile (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '附件ID',
+  file_id VARCHAR(64) NOT NULL COMMENT '业务文件ID，前端使用',
+  session_key VARCHAR(64) NULL COMMENT '关联解析任务session_key，可为空',
+  project_id VARCHAR(64) NOT NULL DEFAULT 'default' COMMENT '项目ID或业务空间ID',
+  file_name VARCHAR(255) NOT NULL COMMENT '服务端存储文件名',
+  original_file_name VARCHAR(255) NOT NULL COMMENT '用户上传原文件名',
+  file_type VARCHAR(32) NOT NULL COMMENT 'text/markdown/pdf/word/excel/unknown',
+  mime_type VARCHAR(128) NULL COMMENT 'MIME类型',
+  file_size BIGINT NOT NULL DEFAULT 0 COMMENT '文件大小，单位字节',
+  file_path VARCHAR(500) NOT NULL COMMENT '服务端文件存储路径',
+  parse_status VARCHAR(32) NOT NULL DEFAULT 'pending' COMMENT 'pending/parsing/success/failed',
+  parse_error TEXT NULL COMMENT '附件解析失败原因',
+  created_by BIGINT NULL COMMENT '上传人ID，暂允许为空',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_requirement_file_id (file_id),
+  KEY idx_requirement_file_project_id (project_id),
+  KEY idx_requirement_file_session_key (session_key),
+  KEY idx_requirement_file_parse_status (parse_status),
+  KEY idx_requirement_file_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='需求输入与解析附件表';
+
+CREATE TABLE IF NOT EXISTS Auto_RequirementFileContent (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '附件内容ID',
+  file_id VARCHAR(64) NOT NULL COMMENT '关联Auto_RequirementFile.file_id',
+  raw_text LONGTEXT NULL COMMENT '附件原始抽取文本',
+  cleaned_text LONGTEXT NULL COMMENT '附件清洗后文本',
+  clean_config JSON NULL COMMENT '本次清洗配置',
+  text_hash VARCHAR(64) NULL COMMENT '清洗后文本SHA256，用于去重和变更判断',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_requirement_file_content_file_id (file_id),
+  KEY idx_requirement_file_content_hash (text_hash),
+  CONSTRAINT fk_requirement_file_content_file_id
+    FOREIGN KEY (file_id) REFERENCES Auto_RequirementFile(file_id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='需求输入与解析附件文本内容表';
+
+CREATE TABLE IF NOT EXISTS Auto_RequirementStructuredResult (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT '结构化解析结果ID',
+  result_id VARCHAR(64) NOT NULL COMMENT '业务结果ID',
+  session_key VARCHAR(64) NOT NULL COMMENT '关联解析任务session_key',
+  summary TEXT NULL COMMENT '需求摘要',
+  business_background TEXT NULL COMMENT '业务背景',
+  functional_requirements JSON NULL COMMENT '功能需求JSON数组',
+  non_functional_requirements JSON NULL COMMENT '非功能需求JSON数组',
+  constraints_json JSON NULL COMMENT '约束条件JSON数组',
+  acceptance_criteria JSON NULL COMMENT '验收标准JSON数组',
+  open_questions JSON NULL COMMENT '待确认问题JSON数组',
+  risk_points JSON NULL COMMENT '风险点JSON数组',
+  modules_json JSON NULL COMMENT '识别到的功能模块JSON数组',
+  source_file_ids JSON NULL COMMENT '来源附件file_id数组',
+  model_name VARCHAR(128) NULL COMMENT 'AI模型名称',
+  prompt_version VARCHAR(64) NULL COMMENT 'Prompt版本',
+  parse_status VARCHAR(32) NOT NULL DEFAULT 'success' COMMENT 'success/failed',
+  parse_error TEXT NULL COMMENT 'AI结构化解析失败原因',
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_requirement_structured_result_id (result_id),
+  KEY idx_requirement_structured_session_key (session_key),
+  KEY idx_requirement_structured_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='需求输入与解析AI结构化结果表';

--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ import tasksRoutes from './routes/tasks';
 import jenkinsRoutes from './routes/jenkins';
 import authRoutes from './routes/auth';
 import aiCasesRoutes from './routes/aiCases';
+import requirementFilesRoutes from './routes/requirementFiles';
 import { dailySummaryScheduler } from './services/DailySummaryScheduler';
 import { executionMonitorService } from './services/ExecutionMonitorService';
 import { initializeWebSocketService, webSocketService } from './services/WebSocketService';
@@ -176,6 +177,7 @@ app.use('/api/cases', casesRoutes);
 app.use('/api/tasks', tasksRoutes);
 app.use('/api/jenkins', jenkinsRoutes);
 app.use('/api/ai-cases', aiCasesRoutes);
+app.use('/api/requirements/files', requirementFilesRoutes);
 
 // 管理员操作速率限制 - 防止滥用和暴力攻击
 const adminRateLimiter = rateLimit({

--- a/server/repositories/RequirementFileRepository.ts
+++ b/server/repositories/RequirementFileRepository.ts
@@ -1,0 +1,188 @@
+import { createHash } from 'crypto';
+import { DataSource } from 'typeorm';
+import { CleanRequirementOptions, RequirementFileRecord } from '../services/requirementFiles/types';
+
+interface SaveRequirementFileInput {
+  fileId: string;
+  sessionKey?: string;
+  projectId: string;
+  fileName: string;
+  originalFileName: string;
+  fileType: string;
+  mimeType: string;
+  fileSize: number;
+  filePath: string;
+  parseStatus: string;
+  parseError?: string | null;
+  rawText?: string;
+  cleanedText?: string;
+  cleanConfig: CleanRequirementOptions;
+}
+
+function hashText(text: string): string {
+  return createHash('sha256').update(text || '').digest('hex');
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+  if (typeof value === 'object') {
+    return value as T;
+  }
+  try {
+    return JSON.parse(String(value)) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function mapRequirementFileRow(row: any): RequirementFileRecord {
+  const cleanConfig = parseJson<CleanRequirementOptions>(row.clean_config, {
+    removeEmptyLines: true,
+    trimExtraSpaces: true,
+    removeInvisibleChars: true,
+    mergeBrokenLines: true,
+    preserveMarkdownTables: true,
+  });
+
+  return {
+    fileId: row.file_id,
+    projectId: row.project_id,
+    fileName: row.original_file_name,
+    originalFileName: row.original_file_name,
+    fileType: row.file_type,
+    fileSize: Number(row.file_size || 0),
+    filePath: row.file_path,
+    mimeType: row.mime_type || '',
+    parseStatus: row.parse_status,
+    parseError: row.parse_error || undefined,
+    rawText: row.raw_text || '',
+    cleanedText: row.cleaned_text || '',
+    cleanConfig,
+    uploadedAt: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    updatedAt: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+  };
+}
+
+export class RequirementFileRepository {
+  constructor(private readonly dataSource: DataSource) {}
+
+  async ensureTables(): Promise<void> {
+    await this.dataSource.query(`
+      CREATE TABLE IF NOT EXISTS Auto_RequirementFile (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        file_id VARCHAR(64) NOT NULL,
+        session_key VARCHAR(64) NULL,
+        project_id VARCHAR(64) NOT NULL DEFAULT 'default',
+        file_name VARCHAR(255) NOT NULL,
+        original_file_name VARCHAR(255) NOT NULL,
+        file_type VARCHAR(32) NOT NULL,
+        mime_type VARCHAR(128) NULL,
+        file_size BIGINT NOT NULL DEFAULT 0,
+        file_path VARCHAR(500) NOT NULL,
+        parse_status VARCHAR(32) NOT NULL DEFAULT 'pending',
+        parse_error TEXT NULL,
+        created_by BIGINT NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        UNIQUE KEY uk_requirement_file_id (file_id),
+        KEY idx_requirement_file_project_id (project_id),
+        KEY idx_requirement_file_session_key (session_key),
+        KEY idx_requirement_file_parse_status (parse_status)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+
+    await this.dataSource.query(`
+      CREATE TABLE IF NOT EXISTS Auto_RequirementFileContent (
+        id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        file_id VARCHAR(64) NOT NULL,
+        raw_text LONGTEXT NULL,
+        cleaned_text LONGTEXT NULL,
+        clean_config JSON NULL,
+        text_hash VARCHAR(64) NULL,
+        created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (id),
+        UNIQUE KEY uk_requirement_file_content_file_id (file_id),
+        KEY idx_requirement_file_content_hash (text_hash),
+        CONSTRAINT fk_requirement_file_content_file_id
+          FOREIGN KEY (file_id) REFERENCES Auto_RequirementFile(file_id)
+          ON DELETE CASCADE
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    `);
+  }
+
+  async saveParsedFile(input: SaveRequirementFileInput): Promise<RequirementFileRecord> {
+    await this.ensureTables();
+
+    await this.dataSource.query(
+      `INSERT INTO Auto_RequirementFile
+        (file_id, session_key, project_id, file_name, original_file_name, file_type, mime_type, file_size, file_path, parse_status, parse_error)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        input.fileId,
+        input.sessionKey || null,
+        input.projectId,
+        input.fileName,
+        input.originalFileName,
+        input.fileType,
+        input.mimeType,
+        input.fileSize,
+        input.filePath,
+        input.parseStatus,
+        input.parseError || null,
+      ]
+    );
+
+    await this.dataSource.query(
+      `INSERT INTO Auto_RequirementFileContent
+        (file_id, raw_text, cleaned_text, clean_config, text_hash)
+       VALUES (?, ?, ?, CAST(? AS JSON), ?)`,
+      [input.fileId, input.rawText || '', input.cleanedText || '', JSON.stringify(input.cleanConfig), hashText(input.cleanedText || '')]
+    );
+
+    const record = await this.findByFileId(input.fileId);
+    if (!record) {
+      throw new Error('保存附件后读取失败');
+    }
+    return record;
+  }
+
+  async findByProjectId(projectId: string): Promise<RequirementFileRecord[]> {
+    await this.ensureTables();
+    const rows = await this.dataSource.query(
+      `SELECT f.*, c.raw_text, c.cleaned_text, c.clean_config
+       FROM Auto_RequirementFile f
+       LEFT JOIN Auto_RequirementFileContent c ON c.file_id = f.file_id
+       WHERE f.project_id = ?
+       ORDER BY f.created_at DESC`,
+      [projectId]
+    );
+    return rows.map(mapRequirementFileRow);
+  }
+
+  async findByFileId(fileId: string): Promise<RequirementFileRecord | null> {
+    await this.ensureTables();
+    const rows = await this.dataSource.query(
+      `SELECT f.*, c.raw_text, c.cleaned_text, c.clean_config
+       FROM Auto_RequirementFile f
+       LEFT JOIN Auto_RequirementFileContent c ON c.file_id = f.file_id
+       WHERE f.file_id = ?
+       LIMIT 1`,
+      [fileId]
+    );
+    return rows.length > 0 ? mapRequirementFileRow(rows[0]) : null;
+  }
+
+  async deleteByFileId(fileId: string): Promise<RequirementFileRecord | null> {
+    await this.ensureTables();
+    const existing = await this.findByFileId(fileId);
+    if (!existing) {
+      return null;
+    }
+    await this.dataSource.query('DELETE FROM Auto_RequirementFile WHERE file_id = ?', [fileId]);
+    return existing;
+  }
+}

--- a/server/repositories/RequirementFileRepository.ts
+++ b/server/repositories/RequirementFileRepository.ts
@@ -139,7 +139,7 @@ export class RequirementFileRepository {
     await this.dataSource.query(
       `INSERT INTO Auto_RequirementFileContent
         (file_id, raw_text, cleaned_text, clean_config, text_hash)
-       VALUES (?, ?, ?, CAST(? AS JSON), ?)`,
+       VALUES (?, ?, ?, ?, ?)`,
       [input.fileId, input.rawText || '', input.cleanedText || '', JSON.stringify(input.cleanConfig), hashText(input.cleanedText || '')]
     );
 

--- a/server/routes/requirementFiles.ts
+++ b/server/routes/requirementFiles.ts
@@ -1,0 +1,116 @@
+import { Router } from 'express';
+import multer from 'multer';
+import { AppDataSource } from '../config/dataSource';
+import { RequirementFileRepository } from '../repositories/RequirementFileRepository';
+import { RequirementFileUploadService } from '../services/requirementFiles/uploadService';
+import { CleanRequirementOptions } from '../services/requirementFiles/types';
+import logger from '../utils/logger';
+import { LOG_CONTEXTS } from '../config/logging';
+
+const router = Router();
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: {
+    fileSize: Number(process.env.REQUIREMENT_FILE_MAX_SIZE || 20 * 1024 * 1024),
+    files: Number(process.env.REQUIREMENT_FILE_MAX_COUNT || 10),
+  },
+});
+
+const repository = new RequirementFileRepository(AppDataSource);
+const uploadService = new RequirementFileUploadService(repository);
+
+function parseCleanConfig(input: unknown): Partial<CleanRequirementOptions> | undefined {
+  if (!input) {
+    return undefined;
+  }
+  if (typeof input === 'object') {
+    return input as Partial<CleanRequirementOptions>;
+  }
+  try {
+    return JSON.parse(String(input)) as Partial<CleanRequirementOptions>;
+  } catch {
+    return undefined;
+  }
+}
+
+function sendSuccess(res: any, data: unknown, message = 'success'): void {
+  res.json({ code: 200, success: true, message, data });
+}
+
+function sendError(res: any, status: number, message: string): void {
+  res.status(status).json({ code: status, success: false, message });
+}
+
+router.post('/upload', upload.array('files'), async (req, res) => {
+  try {
+    const files = (req.files || []) as Express.Multer.File[];
+    const projectId = String(req.body.projectId || 'default');
+    const sessionKey = req.body.sessionKey ? String(req.body.sessionKey) : undefined;
+    const cleanConfig = parseCleanConfig(req.body.cleanConfig);
+
+    const result = await uploadService.uploadFiles({
+      files: files.map((file) => ({
+        originalname: file.originalname,
+        mimetype: file.mimetype,
+        size: file.size,
+        buffer: file.buffer,
+      })),
+      projectId,
+      sessionKey,
+      cleanConfig,
+    });
+
+    sendSuccess(res, result, '上传成功');
+  } catch (error) {
+    logger.errorLog(error, 'Requirement file upload failed', {
+      event: 'REQUIREMENT_FILE_UPLOAD_FAILED',
+      projectId: req.body?.projectId,
+    });
+    sendError(res, 400, error instanceof Error ? error.message : '上传失败');
+  }
+});
+
+router.get('/', async (req, res) => {
+  try {
+    const projectId = String(req.query.projectId || 'default');
+    const files = await uploadService.listFiles(projectId);
+    sendSuccess(res, files);
+  } catch (error) {
+    logger.errorLog(error, 'Requirement file list failed', { event: 'REQUIREMENT_FILE_LIST_FAILED' });
+    sendError(res, 500, error instanceof Error ? error.message : '查询失败');
+  }
+});
+
+router.get('/:fileId/content', async (req, res) => {
+  try {
+    const record = await uploadService.getFileContent(req.params.fileId);
+    if (!record) {
+      return sendError(res, 404, '文件不存在');
+    }
+    sendSuccess(res, record);
+  } catch (error) {
+    logger.errorLog(error, 'Requirement file content failed', {
+      event: 'REQUIREMENT_FILE_CONTENT_FAILED',
+      fileId: req.params.fileId,
+    });
+    sendError(res, 500, error instanceof Error ? error.message : '查询失败');
+  }
+});
+
+router.delete('/:fileId', async (req, res) => {
+  try {
+    const record = await uploadService.deleteFile(req.params.fileId);
+    if (!record) {
+      return sendError(res, 404, '文件不存在');
+    }
+    sendSuccess(res, { fileId: req.params.fileId }, '删除成功');
+  } catch (error) {
+    logger.errorLog(error, 'Requirement file delete failed', {
+      event: 'REQUIREMENT_FILE_DELETE_FAILED',
+      fileId: req.params.fileId,
+    }, LOG_CONTEXTS.CASES);
+    sendError(res, 500, error instanceof Error ? error.message : '删除失败');
+  }
+});
+
+export default router;

--- a/server/routes/requirementFiles.ts
+++ b/server/routes/requirementFiles.ts
@@ -5,7 +5,6 @@ import { RequirementFileRepository } from '../repositories/RequirementFileReposi
 import { RequirementFileUploadService } from '../services/requirementFiles/uploadService';
 import { CleanRequirementOptions } from '../services/requirementFiles/types';
 import logger from '../utils/logger';
-import { LOG_CONTEXTS } from '../config/logging';
 
 const router = Router();
 const upload = multer({
@@ -108,7 +107,7 @@ router.delete('/:fileId', async (req, res) => {
     logger.errorLog(error, 'Requirement file delete failed', {
       event: 'REQUIREMENT_FILE_DELETE_FAILED',
       fileId: req.params.fileId,
-    }, LOG_CONTEXTS.CASES);
+    });
     sendError(res, 500, error instanceof Error ? error.message : '删除失败');
   }
 });

--- a/server/services/requirementFiles/fileParser.ts
+++ b/server/services/requirementFiles/fileParser.ts
@@ -1,0 +1,136 @@
+import fs from 'fs/promises';
+import { TextDecoder } from 'util';
+import { RequirementFileType } from './types';
+
+const supportedExtensions = new Set(['txt', 'text', 'md', 'markdown', 'pdf', 'docx', 'xlsx', 'xls', 'csv']);
+
+export function getRequirementFileType(fileName: string): RequirementFileType {
+  const extension = fileName.split('.').pop()?.toLowerCase() ?? '';
+
+  if (['md', 'markdown'].includes(extension)) {
+    return 'markdown';
+  }
+
+  if (['doc', 'docx'].includes(extension)) {
+    return 'word';
+  }
+
+  if (extension === 'pdf') {
+    return 'pdf';
+  }
+
+  if (['txt', 'text'].includes(extension)) {
+    return 'text';
+  }
+
+  if (['xls', 'xlsx', 'csv'].includes(extension)) {
+    return 'excel';
+  }
+
+  return 'unknown';
+}
+
+export function assertSupportedRequirementFile(originalFileName: string): void {
+  const extension = originalFileName.split('.').pop()?.toLowerCase() ?? '';
+  if (!supportedExtensions.has(extension)) {
+    throw new Error('不支持的文件格式，仅支持 TXT、Markdown、PDF、DOCX、XLS/XLSX、CSV');
+  }
+
+  if (extension === 'doc') {
+    throw new Error('暂不支持旧版 .doc 文件，请转换为 .docx 后上传');
+  }
+}
+
+function decodeTextBuffer(buffer: Buffer): string {
+  const utf8Text = buffer.toString('utf8');
+  const invalidCharCount = (utf8Text.match(/�/g) || []).length;
+
+  if (invalidCharCount <= 3) {
+    return utf8Text;
+  }
+
+  try {
+    return new TextDecoder('gb18030').decode(buffer);
+  } catch {
+    return utf8Text;
+  }
+}
+
+async function parseTextFile(filePath: string): Promise<string> {
+  const buffer = await fs.readFile(filePath);
+  return decodeTextBuffer(buffer);
+}
+
+async function parsePdfFile(filePath: string): Promise<string> {
+  const pdfParseModule = await import('pdf-parse');
+  const pdfParse = (pdfParseModule as any).default || pdfParseModule;
+  const buffer = await fs.readFile(filePath);
+  const data = await pdfParse(buffer);
+  return String(data?.text || '').trim();
+}
+
+async function parseDocxFile(filePath: string): Promise<string> {
+  const mammoth = await import('mammoth');
+  const result = await (mammoth as any).extractRawText({ path: filePath });
+  return String(result?.value || '').trim();
+}
+
+function rowsToMarkdownTable(rows: unknown[][]): string {
+  const validRows = rows.filter((row) => Array.isArray(row) && row.some((cell) => String(cell ?? '').trim().length > 0));
+  if (validRows.length === 0) {
+    return '';
+  }
+
+  const maxColumnCount = Math.max(...validRows.map((row) => row.length));
+  const headers = Array.from({ length: maxColumnCount }).map((_, index) => {
+    const value = String(validRows[0]?.[index] ?? '').trim();
+    return value || `字段${index + 1}`;
+  });
+
+  const lines = [
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+  ];
+
+  validRows.slice(1).forEach((row) => {
+    const cells = headers.map((_, index) => String(row[index] ?? '').replace(/\n/g, ' ').trim());
+    lines.push(`| ${cells.join(' | ')} |`);
+  });
+
+  return lines.join('\n');
+}
+
+async function parseExcelFile(filePath: string): Promise<string> {
+  const XLSX = await import('xlsx');
+  const workbook = (XLSX as any).readFile(filePath);
+  const sections: string[] = [];
+
+  workbook.SheetNames.forEach((sheetName: string) => {
+    const sheet = workbook.Sheets[sheetName];
+    const rows = (XLSX as any).utils.sheet_to_json(sheet, { header: 1, raw: false }) as unknown[][];
+    const table = rowsToMarkdownTable(rows);
+    if (table) {
+      sections.push(`## Sheet: ${sheetName}\n\n${table}`);
+    }
+  });
+
+  return sections.join('\n\n').trim();
+}
+
+export async function parseRequirementFile(filePath: string, originalFileName: string): Promise<string> {
+  const type = getRequirementFileType(originalFileName);
+
+  switch (type) {
+    case 'text':
+    case 'markdown':
+      return parseTextFile(filePath);
+    case 'pdf':
+      return parsePdfFile(filePath);
+    case 'word':
+      return parseDocxFile(filePath);
+    case 'excel':
+      return parseExcelFile(filePath);
+    default:
+      throw new Error('不支持的文件格式');
+  }
+}

--- a/server/services/requirementFiles/storage.ts
+++ b/server/services/requirementFiles/storage.ts
@@ -1,0 +1,70 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+const storageRoot = process.env.REQUIREMENT_FILE_STORAGE_ROOT || path.resolve(process.cwd(), 'storage', 'requirements');
+
+export interface StoredRequirementFile {
+  fileName: string;
+  filePath: string;
+  extension: string;
+}
+
+export function sanitizeOriginalFileName(fileName: string): string {
+  return path.basename(fileName || 'requirement-file').replace(/[\\/:*?"<>|]/g, '_');
+}
+
+export function getFileExtension(fileName: string): string {
+  const extension = path.extname(fileName || '').replace('.', '').toLowerCase();
+  return extension;
+}
+
+function getDatePath(date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}${month}${day}`;
+}
+
+export async function saveRequirementUploadFile(
+  buffer: Buffer,
+  originalFileName: string,
+  projectId: string
+): Promise<StoredRequirementFile> {
+  const extension = getFileExtension(originalFileName);
+  const safeProjectId = String(projectId || 'default').replace(/[^a-zA-Z0-9_-]/g, '_');
+  const directory = path.join(storageRoot, safeProjectId, getDatePath());
+  await fs.mkdir(directory, { recursive: true });
+
+  const fileName = `${randomUUID()}${extension ? `.${extension}` : ''}`;
+  const filePath = path.join(directory, fileName);
+  await fs.writeFile(filePath, buffer);
+
+  return {
+    fileName,
+    filePath,
+    extension,
+  };
+}
+
+export async function deleteStoredRequirementFile(filePath: string): Promise<void> {
+  if (!filePath) {
+    return;
+  }
+
+  const resolvedPath = path.resolve(filePath);
+  const resolvedRoot = path.resolve(storageRoot);
+
+  if (!resolvedPath.startsWith(resolvedRoot)) {
+    throw new Error('非法文件路径，拒绝删除');
+  }
+
+  try {
+    await fs.unlink(resolvedPath);
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+}

--- a/server/services/requirementFiles/textCleaner.ts
+++ b/server/services/requirementFiles/textCleaner.ts
@@ -1,0 +1,110 @@
+import { CleanRequirementOptions, defaultCleanRequirementOptions } from './types';
+
+const markdownTableLinePattern = /^\s*\|.*\|\s*$/;
+const markdownTableDividerPattern = /^\s*\|?\s*:?-{3,}:?\s*(\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+const sentenceEndingPattern = /[。！？.!?；;：:]$/;
+const listOrHeadingPattern = /^\s*(#{1,6}\s|[-*+]\s+|\d+[.)、]\s+|[一二三四五六七八九十]+[、.]|第[一二三四五六七八九十\d]+[章节]|>\s+)/;
+const codeFencePattern = /^\s*```/;
+
+function isMarkdownTableLine(line: string): boolean {
+  return markdownTableLinePattern.test(line) || markdownTableDividerPattern.test(line);
+}
+
+function normalizeVisibleSpacing(line: string): string {
+  const placeholder = '__REQ_INPUT_FULL_WIDTH_SPACE__';
+  return line
+    .replace(/　/g, placeholder)
+    .replace(/[\t ]+/g, ' ')
+    .replace(new RegExp(placeholder, 'g'), ' ')
+    .trim();
+}
+
+function shouldMergeLine(previousLine: string | undefined, currentLine: string, preserveMarkdownTables: boolean): boolean {
+  if (!previousLine || !currentLine) {
+    return false;
+  }
+
+  if (preserveMarkdownTables && (isMarkdownTableLine(previousLine) || isMarkdownTableLine(currentLine))) {
+    return false;
+  }
+
+  if (listOrHeadingPattern.test(previousLine) || listOrHeadingPattern.test(currentLine)) {
+    return false;
+  }
+
+  if (sentenceEndingPattern.test(previousLine)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function cleanRequirementText(
+  input: string,
+  options: Partial<CleanRequirementOptions> = {}
+): string {
+  const mergedOptions: CleanRequirementOptions = {
+    ...defaultCleanRequirementOptions,
+    ...options,
+  };
+
+  let normalizedText = (input || '').replace(/\r\n?/g, '\n');
+
+  if (mergedOptions.removeInvisibleChars) {
+    normalizedText = normalizedText.replace(/[\u200B-\u200D\uFEFF\u2060]/g, '');
+  }
+
+  let insideCodeFence = false;
+  let lines = normalizedText.split('\n').map((line) => {
+    if (codeFencePattern.test(line)) {
+      insideCodeFence = !insideCodeFence;
+      return line.trimEnd();
+    }
+
+    if (insideCodeFence) {
+      return line;
+    }
+
+    if (mergedOptions.preserveMarkdownTables && isMarkdownTableLine(line)) {
+      return line.trim();
+    }
+
+    if (mergedOptions.trimExtraSpaces) {
+      return normalizeVisibleSpacing(line);
+    }
+
+    return line;
+  });
+
+  if (mergedOptions.removeEmptyLines) {
+    lines = lines.filter((line) => line.length > 0);
+  }
+
+  if (!mergedOptions.mergeBrokenLines) {
+    const cleanedText = lines.join('\n');
+    return mergedOptions.trimExtraSpaces ? cleanedText.trim() : cleanedText;
+  }
+
+  const mergedLines: string[] = [];
+  insideCodeFence = false;
+
+  lines.forEach((line) => {
+    if (codeFencePattern.test(line)) {
+      insideCodeFence = !insideCodeFence;
+      mergedLines.push(line);
+      return;
+    }
+
+    const previousLine = mergedLines[mergedLines.length - 1];
+
+    if (!insideCodeFence && shouldMergeLine(previousLine, line, mergedOptions.preserveMarkdownTables)) {
+      mergedLines[mergedLines.length - 1] = `${previousLine}${line.match(/^[,，.。!?！？]/) ? '' : ' '}${line}`;
+      return;
+    }
+
+    mergedLines.push(line);
+  });
+
+  const cleanedText = mergedLines.join('\n');
+  return mergedOptions.trimExtraSpaces ? cleanedText.trim() : cleanedText;
+}

--- a/server/services/requirementFiles/types.ts
+++ b/server/services/requirementFiles/types.ts
@@ -1,0 +1,41 @@
+export type RequirementFileType = 'markdown' | 'word' | 'pdf' | 'text' | 'excel' | 'unknown';
+export type RequirementFileParseStatus = 'pending' | 'parsing' | 'success' | 'failed';
+
+export interface CleanRequirementOptions {
+  removeEmptyLines: boolean;
+  trimExtraSpaces: boolean;
+  removeInvisibleChars: boolean;
+  mergeBrokenLines: boolean;
+  preserveMarkdownTables: boolean;
+}
+
+export interface RequirementFileRecord {
+  fileId: string;
+  projectId: string;
+  fileName: string;
+  originalFileName: string;
+  fileType: RequirementFileType;
+  fileSize: number;
+  filePath: string;
+  mimeType: string;
+  parseStatus: RequirementFileParseStatus;
+  parseError?: string;
+  rawText?: string;
+  cleanedText?: string;
+  cleanConfig: CleanRequirementOptions;
+  uploadedAt: string;
+  updatedAt: string;
+}
+
+export interface RequirementFileUploadResult {
+  files: RequirementFileRecord[];
+  mergedText: string;
+}
+
+export const defaultCleanRequirementOptions: CleanRequirementOptions = {
+  removeEmptyLines: true,
+  trimExtraSpaces: true,
+  removeInvisibleChars: true,
+  mergeBrokenLines: true,
+  preserveMarkdownTables: true,
+};

--- a/server/services/requirementFiles/uploadService.ts
+++ b/server/services/requirementFiles/uploadService.ts
@@ -1,0 +1,107 @@
+import { randomUUID } from 'crypto';
+import { RequirementFileRepository } from '../../repositories/RequirementFileRepository';
+import { cleanRequirementText } from './textCleaner';
+import { assertSupportedRequirementFile, getRequirementFileType, parseRequirementFile } from './fileParser';
+import { deleteStoredRequirementFile, saveRequirementUploadFile, sanitizeOriginalFileName } from './storage';
+import {
+  CleanRequirementOptions,
+  defaultCleanRequirementOptions,
+  RequirementFileRecord,
+  RequirementFileUploadResult,
+} from './types';
+
+export interface RequirementUploadFile {
+  originalname: string;
+  mimetype: string;
+  size: number;
+  buffer: Buffer;
+}
+
+export interface UploadRequirementFilesInput {
+  files: RequirementUploadFile[];
+  projectId: string;
+  sessionKey?: string;
+  cleanConfig?: Partial<CleanRequirementOptions>;
+}
+
+const maxFileSize = Number(process.env.REQUIREMENT_FILE_MAX_SIZE || 20 * 1024 * 1024);
+
+export class RequirementFileUploadService {
+  constructor(private readonly repository: RequirementFileRepository) {}
+
+  async uploadFiles(input: UploadRequirementFilesInput): Promise<RequirementFileUploadResult> {
+    const files = input.files || [];
+    if (files.length === 0) {
+      throw new Error('请选择要上传的需求附件');
+    }
+
+    const cleanConfig: CleanRequirementOptions = {
+      ...defaultCleanRequirementOptions,
+      ...(input.cleanConfig || {}),
+    };
+
+    const records: RequirementFileRecord[] = [];
+
+    for (const file of files) {
+      const safeOriginalName = sanitizeOriginalFileName(file.originalname);
+      if (file.size > maxFileSize) {
+        throw new Error(`文件 ${safeOriginalName} 超过大小限制，单个文件最大支持 20MB`);
+      }
+
+      assertSupportedRequirementFile(safeOriginalName);
+
+      const storedFile = await saveRequirementUploadFile(file.buffer, safeOriginalName, input.projectId);
+      const fileId = `req_file_${randomUUID().replace(/-/g, '')}`;
+      const fileType = getRequirementFileType(safeOriginalName);
+
+      try {
+        const rawText = await parseRequirementFile(storedFile.filePath, safeOriginalName);
+        if (!rawText.trim()) {
+          throw new Error('未提取到有效文本，可能是扫描件或空文件');
+        }
+
+        const cleanedText = cleanRequirementText(rawText, cleanConfig);
+        const record = await this.repository.saveParsedFile({
+          fileId,
+          sessionKey: input.sessionKey,
+          projectId: input.projectId,
+          fileName: storedFile.fileName,
+          originalFileName: safeOriginalName,
+          fileType,
+          mimeType: file.mimetype || '',
+          fileSize: file.size,
+          filePath: storedFile.filePath,
+          parseStatus: 'success',
+          rawText,
+          cleanedText,
+          cleanConfig,
+        });
+        records.push(record);
+      } catch (error) {
+        await deleteStoredRequirementFile(storedFile.filePath).catch(() => undefined);
+        throw new Error(`${safeOriginalName} 解析失败：${error instanceof Error ? error.message : String(error)}`);
+      }
+    }
+
+    return {
+      files: records,
+      mergedText: records.map((record) => record.cleanedText || '').filter(Boolean).join('\n\n'),
+    };
+  }
+
+  async listFiles(projectId: string): Promise<RequirementFileRecord[]> {
+    return this.repository.findByProjectId(projectId || 'default');
+  }
+
+  async getFileContent(fileId: string): Promise<RequirementFileRecord | null> {
+    return this.repository.findByFileId(fileId);
+  }
+
+  async deleteFile(fileId: string): Promise<RequirementFileRecord | null> {
+    const existing = await this.repository.deleteByFileId(fileId);
+    if (existing) {
+      await deleteStoredRequirementFile(existing.filePath).catch(() => undefined);
+    }
+    return existing;
+  }
+}

--- a/server/types/requirement-file-parser-modules.d.ts
+++ b/server/types/requirement-file-parser-modules.d.ts
@@ -1,0 +1,4 @@
+declare module 'pdf-parse';
+declare module 'mammoth';
+declare module 'xlsx';
+declare module 'multer';

--- a/src/pages/cases/RequirementInputParsePage.tsx
+++ b/src/pages/cases/RequirementInputParsePage.tsx
@@ -17,8 +17,15 @@ import {
   saveDraftToStorage,
   CleanRequirementOptions,
 } from "@/pages/cases/requirementInputUtils";
+import {
+  deleteRequirementFile,
+  listRequirementFiles,
+  RequirementFileDto,
+  uploadRequirementFiles,
+} from "@/pages/cases/requirementFileApi";
 
-const textFileTypes = new Set(["markdown", "text", "excel"]);
+const requirementProjectId = "default";
+const requirementSessionKey = "requirement-input-default";
 
 interface ParseAnalysisPanelProps {
   characterCount: number;
@@ -98,14 +105,19 @@ function ParseAnalysisPanel({ characterCount }: ParseAnalysisPanelProps) {
   );
 }
 
-
-function readFileAsText(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
-    reader.onerror = () => reject(new Error(`无法读取文件：${file.name}`));
-    reader.readAsText(file);
-  });
+function mapRequirementFileDto(file: RequirementFileDto): UploadedRequirementFile {
+  return {
+    id: file.fileId,
+    fileId: file.fileId,
+    name: file.originalFileName || file.fileName,
+    size: file.fileSize,
+    type: file.fileType || getFileType(file.originalFileName || file.fileName),
+    extractedText: file.rawText,
+    cleanedText: file.cleanedText,
+    parseStatus: file.parseStatus,
+    parseError: file.parseError,
+    uploadedAt: file.uploadedAt,
+  };
 }
 
 function RequirementInputParsePage() {
@@ -114,6 +126,7 @@ function RequirementInputParsePage() {
   const [rules, setRules] = useState<CleanRequirementOptions>(defaultCleanRequirementOptions);
   const [files, setFiles] = useState<UploadedRequirementFile[]>([]);
   const [progress, setProgress] = useState(35);
+  const [isUploading, setIsUploading] = useState(false);
   const [config, setConfig] = useState<RequirementConfig>({
     title: draft?.title ?? "",
     productLine: draft?.productLine ?? "",
@@ -127,33 +140,74 @@ function RequirementInputParsePage() {
   const characterCount = cleanedText.length;
 
   useEffect(() => {
+    listRequirementFiles(requirementProjectId)
+      .then((remoteFiles) => setFiles(remoteFiles.map(mapRequirementFileDto)))
+      .catch((error: unknown) => {
+        console.warn("加载需求附件失败", error);
+      });
+  }, []);
+
+  useEffect(() => {
     const nextProgress = Math.min(100, 35 + (files.length > 0 ? 15 : 0) + (rawText.trim() ? 25 : 0) + (cleanedText.trim() ? 25 : 0));
     setProgress(nextProgress);
   }, [cleanedText, files.length, rawText]);
 
-  const handleFilesSelected = (selectedFiles: File[]) => {
-    selectedFiles.forEach((file) => {
-      const fileType = getFileType(file.name);
-      const baseFile: UploadedRequirementFile = {
-        id: `${file.name}-${file.lastModified}-${file.size}`,
-        name: file.name,
-        size: file.size,
-        type: fileType,
-      };
+  const handleFilesSelected = async (selectedFiles: File[]) => {
+    if (selectedFiles.length === 0) {
+      return;
+    }
 
-      setFiles((currentFiles) => [...currentFiles, baseFile]);
+    const pendingFiles: UploadedRequirementFile[] = selectedFiles.map((file) => ({
+      id: `pending-${file.name}-${file.lastModified}-${file.size}`,
+      name: file.name,
+      size: file.size,
+      type: getFileType(file.name),
+      parseStatus: "parsing",
+    }));
 
-      if (textFileTypes.has(fileType)) {
-        readFileAsText(file)
-          .then((content) => {
-            setFiles((currentFiles) => currentFiles.map((item) => (item.id === baseFile.id ? { ...item, extractedText: content } : item)));
-            setRawText((currentText) => [currentText, content].filter((item) => item.trim().length > 0).join("\n\n"));
-          })
-          .catch((error: unknown) => {
-            console.warn("读取需求附件失败", error);
-          });
+    setFiles((currentFiles) => [...pendingFiles, ...currentFiles]);
+    setIsUploading(true);
+
+    try {
+      const result = await uploadRequirementFiles({
+        files: selectedFiles,
+        projectId: requirementProjectId,
+        sessionKey: requirementSessionKey,
+        cleanConfig: rules,
+      });
+
+      const uploadedFiles = result.files.map(mapRequirementFileDto);
+      const pendingIds = new Set(pendingFiles.map((file) => file.id));
+      setFiles((currentFiles) => [
+        ...uploadedFiles,
+        ...currentFiles.filter((file) => !pendingIds.has(file.id)),
+      ]);
+
+      if (result.mergedText.trim()) {
+        setRawText((currentText) => [currentText, result.mergedText].filter((item) => item.trim().length > 0).join("\n\n"));
       }
-    });
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : "上传失败";
+      const pendingIds = new Set(pendingFiles.map((file) => file.id));
+      setFiles((currentFiles) => currentFiles.map((file) => (
+        pendingIds.has(file.id) ? { ...file, parseStatus: "failed", parseError: message } : file
+      )));
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleRemoveFile = async (id: string) => {
+    const target = files.find((file) => file.id === id);
+    setFiles((currentFiles) => currentFiles.filter((file) => file.id !== id));
+
+    if (target?.fileId) {
+      try {
+        await deleteRequirementFile(target.fileId);
+      } catch (error: unknown) {
+        console.warn("删除需求附件失败", error);
+      }
+    }
   };
 
   const handleSaveDraft = () => {
@@ -219,10 +273,10 @@ function RequirementInputParsePage() {
         <div className="grid w-full min-w-0 grid-cols-1 items-start gap-6 xl:grid-cols-[300px_minmax(0,1fr)] 2xl:grid-cols-[320px_minmax(0,1fr)_320px]">
           {/* Left column */}
           <aside className="w-full space-y-4">
-            <RequirementUploadPanel onFilesSelected={handleFilesSelected} />
+            <RequirementUploadPanel onFilesSelected={handleFilesSelected} disabled={isUploading} />
             <UploadedFileList
               files={files}
-              onRemove={(id) => setFiles((currentFiles) => currentFiles.filter((file) => file.id !== id))}
+              onRemove={handleRemoveFile}
             />
             <CleanRulesPanel rules={rules} onChange={setRules} />
           </aside>

--- a/src/pages/cases/components/RequirementUploadPanel.tsx
+++ b/src/pages/cases/components/RequirementUploadPanel.tsx
@@ -1,11 +1,27 @@
+import { useId, useState } from "react";
 import { UploadCloud } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface RequirementUploadPanelProps {
   onFilesSelected: (files: File[]) => void;
+  disabled?: boolean;
 }
 
-function RequirementUploadPanel({ onFilesSelected }: RequirementUploadPanelProps) {
+function RequirementUploadPanel({ onFilesSelected, disabled = false }: RequirementUploadPanelProps) {
+  const inputId = useId();
+  const [isDragging, setIsDragging] = useState(false);
+
+  const handleFiles = (fileList: FileList | null) => {
+    if (disabled) {
+      return;
+    }
+
+    const files = Array.from(fileList ?? []);
+    if (files.length > 0) {
+      onFilesSelected(files);
+    }
+  };
+
   return (
     <div className="w-full rounded-2xl border border-slate-200/60 bg-white p-5 shadow-sm transition-shadow hover:shadow-md dark:border-slate-800/60 dark:bg-[#131729]">
       <div className="mb-4 flex items-center gap-3">
@@ -21,7 +37,50 @@ function RequirementUploadPanel({ onFilesSelected }: RequirementUploadPanelProps
           </p>
         </div>
       </div>
-      <label className="group flex cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-slate-50/50 px-6 py-8 text-center transition-all duration-200 hover:border-[#39E079]/50 hover:bg-[#39E079]/5 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:border-[#39E079]/30 dark:hover:bg-[#39E079]/5">
+
+      <input
+        id={inputId}
+        className="sr-only"
+        multiple
+        disabled={disabled}
+        type="file"
+        accept=".txt,.md,.markdown,.pdf,.doc,.docx,.xls,.xlsx,.csv"
+        onChange={(event) => {
+          handleFiles(event.target.files);
+          event.target.value = "";
+        }}
+      />
+
+      <label
+        htmlFor={inputId}
+        className={`group flex cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed px-6 py-8 text-center transition-all duration-200 ${
+          isDragging
+            ? "border-[#39E079]/70 bg-[#39E079]/10"
+            : "border-slate-300 bg-slate-50/50 hover:border-[#39E079]/50 hover:bg-[#39E079]/5 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:border-[#39E079]/30 dark:hover:bg-[#39E079]/5"
+        } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+        onDragEnter={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          if (!disabled) {
+            setIsDragging(true);
+          }
+        }}
+        onDragOver={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        onDragLeave={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsDragging(false);
+        }}
+        onDrop={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          setIsDragging(false);
+          handleFiles(event.dataTransfer.files);
+        }}
+      >
         <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 transition-colors duration-200 group-hover:bg-[#39E079]/15 dark:bg-slate-800 dark:group-hover:bg-[#39E079]/10">
           <UploadCloud className="h-5 w-5 text-slate-400 transition-colors duration-200 group-hover:text-[#2ba85a] dark:text-slate-500 dark:group-hover:text-[#39E079]" />
         </div>
@@ -31,22 +90,13 @@ function RequirementUploadPanel({ onFilesSelected }: RequirementUploadPanelProps
         <span className="mt-1 text-xs text-slate-400 dark:text-slate-500">
           文本类文件会自动读取内容，可与文本输入合并
         </span>
-        <input
-          className="sr-only"
-          multiple
-          type="file"
-          accept=".txt,.md,.markdown,.pdf,.doc,.docx,.xls,.xlsx,.csv"
-          onChange={(event) => {
-            onFilesSelected(Array.from(event.target.files ?? []));
-            event.target.value = "";
-          }}
-        />
         <Button
+          asChild
           className="mt-4 h-8 rounded-lg border border-slate-200 bg-white px-4 text-xs font-medium shadow-none transition-all hover:bg-slate-50 hover:shadow-sm dark:border-slate-700 dark:bg-slate-800 dark:hover:bg-slate-750"
           type="button"
           variant="outline"
         >
-          选择文件
+          <span>选择文件</span>
         </Button>
       </label>
     </div>

--- a/src/pages/cases/components/UploadedFileList.tsx
+++ b/src/pages/cases/components/UploadedFileList.tsx
@@ -2,18 +2,40 @@ import { FileText, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { formatFileSize, RequirementFileType } from "@/pages/cases/requirementInputUtils";
+import { RequirementFileParseStatus } from "@/pages/cases/requirementFileApi";
 
 export interface UploadedRequirementFile {
   id: string;
+  fileId?: string;
   name: string;
   size: number;
   type: RequirementFileType;
   extractedText?: string;
+  cleanedText?: string;
+  parseStatus?: RequirementFileParseStatus;
+  parseError?: string;
+  uploadedAt?: string;
 }
 
 interface UploadedFileListProps {
   files: UploadedRequirementFile[];
   onRemove: (id: string) => void;
+}
+
+function getStatusBadge(file: UploadedRequirementFile) {
+  if (file.parseStatus === "failed") {
+    return <Badge className="bg-red-50 text-red-600 dark:bg-red-950/30 dark:text-red-400">解析失败</Badge>;
+  }
+
+  if (file.parseStatus === "success" || file.extractedText || file.cleanedText) {
+    return <Badge className="bg-[#39E079]/10 text-[#2ba85a] dark:bg-[#39E079]/15 dark:text-[#39E079]">已读取</Badge>;
+  }
+
+  if (file.parseStatus === "parsing" || file.parseStatus === "pending") {
+    return <Badge className="bg-blue-50 text-blue-600 dark:bg-blue-950/30 dark:text-blue-400">解析中</Badge>;
+  }
+
+  return <Badge className="bg-amber-50 text-amber-600 dark:bg-amber-950/30 dark:text-amber-400">待解析</Badge>;
 }
 
 function UploadedFileList({ files, onRemove }: UploadedFileListProps) {
@@ -36,46 +58,45 @@ function UploadedFileList({ files, onRemove }: UploadedFileListProps) {
           files.map((file, index) => (
             <div
               key={file.id}
-              className="group flex items-center justify-between rounded-xl border border-slate-100 bg-slate-50/50 px-3 py-2.5 transition-all duration-200 hover:border-slate-200 hover:bg-white hover:shadow-sm dark:border-slate-800/60 dark:bg-slate-900/30 dark:hover:border-slate-700 dark:hover:bg-slate-900/50"
+              className="group rounded-xl border border-slate-100 bg-slate-50/50 px-3 py-2.5 transition-all duration-200 hover:border-slate-200 hover:bg-white hover:shadow-sm dark:border-slate-800/60 dark:bg-slate-900/30 dark:hover:border-slate-700 dark:hover:bg-slate-900/50"
               style={{ animationDelay: `${index * 50}ms` }}
             >
-              <div className="flex min-w-0 items-center gap-3">
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-950/40">
-                  <FileText className="h-4 w-4 text-blue-500 dark:text-blue-400" />
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-950/40">
+                    <FileText className="h-4 w-4 text-blue-500 dark:text-blue-400" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">
+                      {file.name}
+                    </p>
+                    <p className="text-xs text-slate-400 dark:text-slate-500">
+                      {formatFileSize(file.size)}{file.uploadedAt ? ` · ${new Date(file.uploadedAt).toLocaleString()}` : ""}
+                    </p>
+                  </div>
                 </div>
-                <div className="min-w-0">
-                  <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">
-                    {file.name}
-                  </p>
-                  <p className="text-xs text-slate-400 dark:text-slate-500">
-                    {formatFileSize(file.size)}
-                  </p>
+                <div className="flex items-center gap-2">
+                  <Badge className="bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                    {file.type}
+                  </Badge>
+                  {getStatusBadge(file)}
+                  <Button
+                    aria-label={`移除 ${file.name}`}
+                    className="h-7 w-7 rounded-lg opacity-0 transition-all duration-200 hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-red-950/30"
+                    size="icon"
+                    type="button"
+                    variant="ghost"
+                    onClick={() => onRemove(file.id)}
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </Button>
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                <Badge className="bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300">
-                  {file.type}
-                </Badge>
-                {file.extractedText ? (
-                  <Badge className="bg-[#39E079]/10 text-[#2ba85a] dark:bg-[#39E079]/15 dark:text-[#39E079]">
-                    已读取
-                  </Badge>
-                ) : (
-                  <Badge className="bg-amber-50 text-amber-600 dark:bg-amber-950/30 dark:text-amber-400">
-                    待解析
-                  </Badge>
-                )}
-                <Button
-                  aria-label={`移除 ${file.name}`}
-                  className="h-7 w-7 rounded-lg opacity-0 transition-all duration-200 hover:bg-red-50 hover:text-red-500 group-hover:opacity-100 dark:hover:bg-red-950/30"
-                  size="icon"
-                  type="button"
-                  variant="ghost"
-                  onClick={() => onRemove(file.id)}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </Button>
-              </div>
+              {file.parseError && (
+                <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600 dark:bg-red-950/20 dark:text-red-400">
+                  {file.parseError}
+                </p>
+              )}
             </div>
           ))
         )}

--- a/src/pages/cases/requirementFileApi.ts
+++ b/src/pages/cases/requirementFileApi.ts
@@ -1,0 +1,77 @@
+import { CleanRequirementOptions, RequirementFileType } from '@/pages/cases/requirementInputUtils';
+
+export type RequirementFileParseStatus = 'pending' | 'parsing' | 'success' | 'failed';
+
+export interface RequirementFileDto {
+  fileId: string;
+  projectId: string;
+  fileName: string;
+  originalFileName?: string;
+  fileType: RequirementFileType;
+  fileSize: number;
+  filePath?: string;
+  mimeType?: string;
+  parseStatus: RequirementFileParseStatus;
+  parseError?: string;
+  rawText?: string;
+  cleanedText?: string;
+  cleanConfig?: CleanRequirementOptions;
+  uploadedAt: string;
+  updatedAt?: string;
+}
+
+export interface UploadRequirementFilesResponse {
+  files: RequirementFileDto[];
+  mergedText: string;
+}
+
+interface ApiResponse<T> {
+  code?: number;
+  success?: boolean;
+  message?: string;
+  data: T;
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const payload = await response.json().catch(() => null) as ApiResponse<T> | null;
+
+  if (!response.ok || payload?.success === false) {
+    throw new Error(payload?.message || '请求失败');
+  }
+
+  return payload?.data as T;
+}
+
+export async function uploadRequirementFiles(params: {
+  files: File[];
+  projectId: string;
+  sessionKey?: string;
+  cleanConfig: CleanRequirementOptions;
+}): Promise<UploadRequirementFilesResponse> {
+  const formData = new FormData();
+  params.files.forEach((file) => formData.append('files', file));
+  formData.append('projectId', params.projectId || 'default');
+  if (params.sessionKey) {
+    formData.append('sessionKey', params.sessionKey);
+  }
+  formData.append('cleanConfig', JSON.stringify(params.cleanConfig));
+
+  const response = await fetch('/api/requirements/files/upload', {
+    method: 'POST',
+    body: formData,
+  });
+
+  return parseResponse<UploadRequirementFilesResponse>(response);
+}
+
+export async function listRequirementFiles(projectId: string): Promise<RequirementFileDto[]> {
+  const response = await fetch(`/api/requirements/files?projectId=${encodeURIComponent(projectId || 'default')}`);
+  return parseResponse<RequirementFileDto[]>(response);
+}
+
+export async function deleteRequirementFile(fileId: string): Promise<void> {
+  const response = await fetch(`/api/requirements/files/${encodeURIComponent(fileId)}`, {
+    method: 'DELETE',
+  });
+  await parseResponse<{ fileId: string }>(response);
+}


### PR DESCRIPTION
## 变更说明

本 PR 针对“需求输入与解析”页面补齐附件上传、后端解析、数据库持久化能力。

## 已完成

- 修复上传区域点击选择文件无法稳定唤起系统文件选择窗口的问题
- 增加拖拽上传交互
- 前端接入真实接口 `/api/requirements/files/upload`
- 增加附件列表查询、删除、解析状态展示
- 增加后端文件上传路由 `server/routes/requirementFiles.ts`
- 增加文件存储服务、解析服务、清洗服务、上传编排服务
- 支持 TXT、Markdown、PDF、DOCX、XLS/XLSX、CSV 解析
- 增加页面级数据库 SQL：解析任务、附件、附件内容、结构化结果
- 增加附件 repository，写入 `Auto_RequirementFile` 与 `Auto_RequirementFileContent`
- 增加依赖：multer、pdf-parse、mammoth、xlsx

## 数据库设计

新增 SQL 文件：

```text
server/database/requirement-input-parse-schema.sql
```

包含：

- `Auto_RequirementParseSession`
- `Auto_RequirementFile`
- `Auto_RequirementFileContent`
- `Auto_RequirementStructuredResult`

## 后续建议

- 接入 AI 结构化解析接口，写入 `Auto_RequirementStructuredResult`
- 将当前固定 `projectId=default` 改为真实项目上下文
- 补充上传接口单元测试与前端交互测试

Closes #125