### PR TITLE
fix(callback): reconcile lightweight Jenkins success results

### DIFF
--- a/server/repositories/ExecutionRepositoryBatch.ts
+++ b/server/repositories/ExecutionRepositoryBatch.ts
@@ -27,6 +27,19 @@ import type {
   TestRunStatusInfo,
   TestRunWithUser,
 } from './ExecutionRepositoryTypes';
+
+export function shouldPromoteFailedPlaceholdersForZeroSummarySuccess(input: {
+  status: string;
+  dbTotal: number;
+  dbFailed: number;
+  dbFinished: number;
+}): boolean {
+  return input.status === 'success'
+    && input.dbTotal > 0
+    && input.dbFailed > 0
+    && input.dbFinished === input.dbFailed;
+}
+
 export abstract class ExecutionRepositoryBatch extends ExecutionRepositoryStatusUtilities {
   abstract bulkUpdateErrorResults(executionId: number, targetStatus: 'passed' | 'failed' | 'skipped'): Promise<number>;
 
@@ -929,7 +942,32 @@ export abstract class ExecutionRepositoryBatch extends ExecutionRepositoryStatus
         const dbTotal    = Number(countRows[0].total       ?? 0);
         const dbFinished = dbPassed + dbFailed + dbSkipped;
 
-        if (dbTotal > 0 && dbFinished > 0) {
+        if (shouldPromoteFailedPlaceholdersForZeroSummarySuccess({
+          status: results.status,
+          dbTotal,
+          dbFailed,
+          dbFinished,
+        })) {
+          await this.testRunResultRepository.query(`
+            UPDATE Auto_TestRunResults
+            SET status = 'passed',
+                end_time = COALESCE(end_time, NOW())
+            WHERE execution_id = ? AND status = 'failed'
+          `, [executionId]);
+
+          const newCounts = await this.countResultsByStatus(executionId);
+          await this.testRunRepository.update(runId, {
+            passedCases:  newCounts.passed,
+            failedCases:  newCounts.failed,
+            skippedCases: newCounts.skipped,
+          });
+
+          logger.info(
+            `Reconciled zero-summary success callback from failed placeholders`,
+            { runId, executionId, previousFailed: dbFailed, newCounts },
+            LOG_CONTEXTS.REPOSITORY
+          );
+        } else if (dbTotal > 0 && dbFinished > 0) {
           // 已有非 error 的真实结果，直接用统计值回填 Auto_TestRun，不覆盖为0
           await this.testRunRepository.update(runId, {
             passedCases:  dbPassed,

--- a/test_case/backend/callbackStatus.test.ts
+++ b/test_case/backend/callbackStatus.test.ts
@@ -4,6 +4,7 @@ import {
   deriveCallbackTerminalStatus,
   normalizeCallbackTerminalStatus,
 } from '../../server/services/ExecutionService/callbackStatus';
+import { shouldPromoteFailedPlaceholdersForZeroSummarySuccess } from '../../server/repositories/ExecutionRepositoryBatch';
 
 describe('callback status derivation', () => {
   it('treats mixed passed and failed case results as failed overall', () => {
@@ -37,5 +38,34 @@ describe('callback status derivation', () => {
     });
 
     expect(status).toBe('aborted');
+  });
+});
+
+describe('zero-summary success callback reconciliation', () => {
+  it('promotes failed placeholders when Jenkins reports success without result details', () => {
+    expect(shouldPromoteFailedPlaceholdersForZeroSummarySuccess({
+      status: 'success',
+      dbTotal: 2,
+      dbFailed: 2,
+      dbFinished: 2,
+    })).toBe(true);
+  });
+
+  it('does not promote mixed persisted results that may contain real failures', () => {
+    expect(shouldPromoteFailedPlaceholdersForZeroSummarySuccess({
+      status: 'success',
+      dbTotal: 2,
+      dbFailed: 1,
+      dbFinished: 2,
+    })).toBe(false);
+  });
+
+  it('does not promote placeholders for non-success Jenkins results', () => {
+    expect(shouldPromoteFailedPlaceholdersForZeroSummarySuccess({
+      status: 'failed',
+      dbTotal: 2,
+      dbFailed: 2,
+      dbFinished: 2,
+    })).toBe(false);
   });
 });


### PR DESCRIPTION
Handle zero-summary Jenkins success callbacks so failed placeholder rows do not incorrectly keep platform runs marked as failed.

Add focused backend tests for placeholder promotion and mixed-result protection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了回调汇总结果的处理逻辑，减少“汇总成功但明细为空/不完整”时统计异常的问题。
  * 在特定空结果场景下，会更准确地修正失败占位记录的状态，并同步更新整体统计信息。
  * 增加了相关校验，避免在非成功回调或混合结果场景中误修正数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->